### PR TITLE
Add file directives and some descriptions from PyPoE

### DIFF
--- a/dat-schema/1_00_Domination.gql
+++ b/dat-schema/1_00_Domination.gql
@@ -30,6 +30,6 @@ type Shrines {
 
 type ShrineSounds {
   Id: string @unique
-  StereoSoundFile: string
-  MonoSoundFile: string
+  StereoSoundFile: string @file(ext: ".ogg")
+  MonoSoundFile: string @file(ext: ".ogg")
 }

--- a/dat-schema/2_02_Ascendancy.gql
+++ b/dat-schema/2_02_Ascendancy.gql
@@ -60,7 +60,7 @@ type LabyrinthSecretEffects {
   MonsterVarietiesKey: MonsterVarieties
   Buff_BuffDefinitionsKey: BuffDefinitions
   Buff_StatValues: [i32]
-  OTFile: string
+  OTFile: string @file(ext: ".ot")
 }
 
 enum LabyrinthSecretLocations { _ }

--- a/dat-schema/2_02_Ascendancy.gql
+++ b/dat-schema/2_02_Ascendancy.gql
@@ -19,7 +19,7 @@ type LabyrinthExclusionGroups {
 }
 
 type LabyrinthIzaroChests {
-  Id: string @unique
+  Id: string @unique @files(ext: [".ot", ".otc"])
   ChestsKey: Chests
   SpawnWeight: i32
   MinLabyrinthTier: i32
@@ -35,7 +35,7 @@ type LabyrinthNodeOverrides {
 
 type LabyrinthRewardTypes {
   Id: string @unique
-  ObjectPath: string
+  ObjectPath: string @files(ext: [".ot", ".otc"])
 }
 
 type Labyrinths {

--- a/dat-schema/2_03_Prophecy.gql
+++ b/dat-schema/2_03_Prophecy.gql
@@ -6,7 +6,7 @@ type Prophecies {
   Name: string
   FlavourText: string
   QuestTracker_ClientStringsKeys: [ClientStrings]
-  OGGFile: string
+  OGGFile: string @file(ext: ".ogg")
   ProphecyChainKey: ProphecyChain
   ProphecyChainPosition: i32
   IsEnabled: bool

--- a/dat-schema/3_01_Abyss.gql
+++ b/dat-schema/3_01_Abyss.gql
@@ -5,7 +5,7 @@ type AbyssObjects {
   MaxLevel: i32
   SpawnWeight: i32
   _: i32
-  MetadataFile: string
+  MetadataFile: string @files(ext: [".ot", ".otc"])
   _: i32
   DaemonSpawners: [MonsterVarieties]
   _: i32

--- a/dat-schema/3_02_Bestiary.gql
+++ b/dat-schema/3_02_Bestiary.gql
@@ -52,7 +52,7 @@ type BestiaryGenus {
 type BestiaryGroups {
   Id: string @unique
   Description: string
-  Illustraiton: string
+  Illustration: string
   Name: string
   Icon: string
   IconSmall: string

--- a/dat-schema/3_03_Incursion.gql
+++ b/dat-schema/3_03_Incursion.gql
@@ -21,7 +21,7 @@ type IncursionBrackets {
 type IncursionChestRewards {
   IncursionRoomsKey: IncursionRooms
   IncursionChestsKeys: [IncursionChests]
-  _: string
+  ChestMarkerMetadata: string @files(ext: [".ot", ".otc"])
   _: u32
   _: i32
   _: i32

--- a/dat-schema/3_03_Incursion.gql
+++ b/dat-schema/3_03_Incursion.gql
@@ -54,11 +54,11 @@ type IncursionRooms {
   MinLevel: i32
   RoomUpgrade_IncursionRoomsKey: IncursionRooms
   ModsKey: Mods
-  PresentARMFile: string
+  PresentARMFile: string @file(ext: ".arm")
   IntId: i32 @unique
   IncursionArchitectKey: IncursionArchitect
-  PastARMFile: string
-  TSIFile: string
+  PastARMFile: string @file(ext: ".arm")
+  TSIFile: string @file(ext: ".tsi")
   UIIcon: string
   FlavourText: string
   Description: string

--- a/dat-schema/3_04_Delve.gql
+++ b/dat-schema/3_04_Delve.gql
@@ -163,7 +163,7 @@ type DelveResourcePerLevel {
 type DelveRooms {
   DelveBiomesKey: DelveBiomes
   DelveFeaturesKey: DelveFeatures
-  ARMFile: string
+  ARMFile: string @file(ext: ".arm")
 }
 
 type DelveUpgrades {

--- a/dat-schema/3_04_Delve.gql
+++ b/dat-schema/3_04_Delve.gql
@@ -16,8 +16,7 @@ type DelveBiomes {
   SpawnWeight_Values: [i32]
   _: [i32]
   _: [i32]
-  Art2D: string @files(ext: ["1.dds", "2.dds", "3.dds", "4.dds", "5.dds", "6.dds", "7.dds", "8.dds", "9.dds",
-    "1.dds.header", "2.dds.header", "3.dds.header", "4.dds.header", "5.dds.header", "6.dds.header", "7.dds.header", "8.dds.header", "9.dds.header"])
+  Art2D: string @files(ext: [".dds"])
   AchievementItemsKeys: [AchievementItems]
   _: bool
   _: [i32]

--- a/dat-schema/3_04_Delve.gql
+++ b/dat-schema/3_04_Delve.gql
@@ -16,7 +16,8 @@ type DelveBiomes {
   SpawnWeight_Values: [i32]
   _: [i32]
   _: [i32]
-  Art2D: string
+  Art2D: string @files(ext: ["1.dds", "2.dds", "3.dds", "4.dds", "5.dds", "6.dds", "7.dds", "8.dds", "9.dds",
+    "1.dds.header", "2.dds.header", "3.dds.header", "4.dds.header", "5.dds.header", "6.dds.header", "7.dds.header", "8.dds.header", "9.dds.header"])
   AchievementItemsKeys: [AchievementItems]
   _: bool
   _: [i32]

--- a/dat-schema/3_05_Betrayal.gql
+++ b/dat-schema/3_05_Betrayal.gql
@@ -89,7 +89,7 @@ type BetrayalTargets {
   _: i8
   _: rid
   FullName: string
-  Safehouse_ARMFile: string
+  Safehouse_ARMFile: string @file(ext: ".arm")
   ShortName: string
   _: i32
   SafehouseLeader_AcheivementItemsKey: AchievementItems

--- a/dat-schema/3_11_Harvest.gql
+++ b/dat-schema/3_11_Harvest.gql
@@ -18,6 +18,7 @@ type HarvestCraftOptions {
   _: bool
   _: i32
   HarvestCraftOptionIconsKeys: [HarvestCraftOptionIcons]
+  "Text without any tags for formatting"
   PlainText: string
 }
 

--- a/dat-schema/3_11_Harvest.gql
+++ b/dat-schema/3_11_Harvest.gql
@@ -3,7 +3,7 @@ enum HarvestColours { _ }
 
 type HarvestCraftOptionIcons {
   Id: string @unique
-  DDSFile: string
+  DDSFile: string @file(ext: ".dds")
 }
 
 type HarvestCraftOptions {
@@ -59,7 +59,7 @@ enum HarvestMetaCraftingOptions { _ }
 
 type HarvestObjects {
   BaseItemTypesKey: BaseItemTypes @unique
-  AOFile: string
+  AOFile: string @file(ext: ".ao")
   ObjectType: i32
 }
 
@@ -95,7 +95,7 @@ type HarvestSeedTypes {
   HarvestObjectsKey: HarvestObjects @unique
   _: rid
   GrowthCycles: i32
-  AOFiles: [string]
+  AOFiles: [string] @file(ext: ".ao")
   _: [i32]
   _: i32
   Tier: i32

--- a/dat-schema/3_12_Heist.gql
+++ b/dat-schema/3_12_Heist.gql
@@ -24,12 +24,12 @@ type HeistAreas {
   HeistJobsKeys: [HeistJobs]
   Contract_BaseItemTypesKey: BaseItemTypes
   Blueprint_BaseItemTypesKey: BaseItemTypes
-  DGRFile: string
+  DGRFile: string @file(ext: ".dgr")
   _: i32
   _: i32
   _: bool
   _: bool
-  Blueprint_DDSFile: string
+  Blueprint_DDSFile: string @file(ext: ".dds")
   AchievementItemsKeys: [AchievementItems]
   AchievementItemsKeys2: [AchievementItems]
   ClientStringsKey: ClientStrings
@@ -116,7 +116,7 @@ type HeistDoodadNPCs {
   _: i32
   _: i32
   _: i32
-  AOFile: string
+  AOFile: string @file(ext: ".ao")
   Stance: string
   _: rid
 }
@@ -170,7 +170,7 @@ type HeistIntroAreas {
   _: rid
   _: i32
   _: i32
-  DGRFile: string
+  DGRFile: string @file(ext: ".dgr")
   _: i32
   _: i32
   _: i8
@@ -246,7 +246,7 @@ type HeistNPCs {
   ActiveNPCIcon: string
   HeistJobsKey: HeistJobs
   Equip_AchievementItemsKeys: [AchievementItems]
-  AOFile: string
+  AOFile: string @file(ext: ".ao")
 }
 
 type HeistNPCStats {
@@ -323,7 +323,7 @@ type HeistRevealingNPCs {
 type HeistRooms {
   HeistJobsKey: HeistJobs
   Id: i32
-  ARMFile: string
+  ARMFile: string @file(ext: ".arm")
   _: rid
   _: rid
   _: i32

--- a/dat-schema/_Core.gql
+++ b/dat-schema/_Core.gql
@@ -61,19 +61,19 @@ type ActiveSkills {
   Description: string
   _: string
   Icon_DDSFile: string @file(ext: ".dds")
-  ActiveSkillTargetTypes: [u32]
-  ActiveSkillTypes: [u32]
+  ActiveSkillTargetTypes: [ActiveSkillTargetTypes]
+  ActiveSkillTypes: [ActiveSkillType]
   WeaponRestriction_ItemClassesKeys: [ItemClasses]
   WebsiteDescription: string
   WebsiteImage: string
   _: bool
   _: string
   _: bool
-  SkillTotemId: i32
+  SkillTotemId: SkillTotems
   IsManuallyCasted: bool
   Input_StatKeys: [Stats]
   Output_StatKeys: [Stats]
-  MinionActiveSkillTypes: [i32]
+  MinionActiveSkillTypes: [ActiveSkillType]
   _: bool
   _: bool
   _: [rid]
@@ -306,6 +306,7 @@ type Ascendancy {
   Id: string @unique
   ClassNo: i32
   CharactersKey: Characters
+  "Coordinates in 'x1, y1, x2, y2' format"
   CoordinateRect: string
   RGBFlavourTextColour: string
   Name: string
@@ -476,12 +477,14 @@ type BaseItemTypes {
   RarePurchase_Costs: [i32]
   UniquePurchase_BaseItemTypesKeys: [BaseItemTypes]
   UniquePurchase_Costs: [i32]
+  "the inflection identifier used for i18n in related fields"
   Inflection: string
   Equip_AchievementItemsKey: AchievementItems
   IsCorrupted: bool
   Identify_AchievementItemsKeys: [AchievementItems]
   ItemThemesKey: ItemThemes
   IdentifyMagic_AchievementItemsKeys: [AchievementItems]
+  "the item which represents this item in the fragment stash tab"
   FragmentBaseItemTypesKey: BaseItemTypes
   _: bool
   ItemShopType: ItemShopType
@@ -655,7 +658,9 @@ type CharacterAudioEvents {
   Shadow_CharacterTextAudioKeys: [CharacterTextAudio]
   Templar_CharacterTextAudioKeys: [CharacterTextAudio]
   Scion_CharacterTextAudioKeys: [CharacterTextAudio]
+  "For the Goddess Bound/Scorned/Unleashed unique"
   Goddess_CharacterTextAudioKeys: [CharacterTextAudio]
+  "For Jack the Axe unique"
   JackTheAxe_CharacterTextAudioKeys: [CharacterTextAudio]
   _: bool
 }
@@ -694,6 +699,7 @@ type Characters {
   ACTFile: string @file(ext: ".act")
   BaseMaxLife: i32
   BaseMaxMana: i32
+  "Attack Speed in milliseconds"
   WeaponSpeed: i32
   MinDamage: i32
   MaxDamage: i32
@@ -924,6 +930,7 @@ type CurrencyItems {
   CurrencyUseType: i32
   Action: string
   Directions: string
+  "Full stack transforms into this item"
   FullStack_BaseItemTypesKey: BaseItemTypes
   Description: string
   Usage_AchievementItemsKeys: [AchievementItems]
@@ -1366,6 +1373,7 @@ type Flasks {
   Group: i32
   LifePerUse: i32
   ManaPerUse: i32
+  "in 1/10 s"
   RecoveryTime: i32
   BuffDefinitionsKey: BuffDefinitions
   BuffStatValues: [i32]
@@ -1599,13 +1607,17 @@ type GrantedEffectQualityTypes {
 type GrantedEffects {
   Id: string @unique
   IsSupport: bool
+  "This support gem only supports active skills with at least one of these types"
   AllowedActiveSkillTypes: [u32]
   BaseEffectiveness: f32
   IncrementalEffectiveness: f32
   SupportGemLetter: string
   _: i32
+  "This support gem adds these types to supported active skills"
   AddedActiveSkillTypes: [u32]
+  "This support gem does not support active skills with one of these types"
   ExcludedActiveSkillTypes: [u32]
+  "This support gem only supports active skills that come from gem items"
   SupportsGemsOnly: bool
   _: u32
   _: [i32]
@@ -1651,21 +1663,25 @@ type GrantedEffectsPerLevel {
   LevelRequirement2: i32
   LevelRequirement3: i32
   CriticalStrikeChance: i32
+  "Damage effectiveness based on 0 = 100%"
   DamageEffectiveness: i32
   StoredUses: i32
   Cooldown: i32
-  CooldownBypassType: i32
+  CooldownBypassType: CooldownBypassTypes
+  "Used with a value of one"
   StatsKeys2: [Stats]
   _: bool
   VaalSouls: i32
   VaalStoredUses: i32
   CooldownGroup: i32
   _: i32
+  "Damage multiplier in 1/10000 for attack skills"
   DamageMultiplier: i32
   _: i32
   ArtVariation: i32
   StatInterpolationTypesKeys: [i32]
   _: i32
+  "Time in milliseconds"
   VaalSoulGainPreventionTime: i32
   BaseDuration: i32
   AttackSpeedMultiplier: i32
@@ -1801,6 +1817,7 @@ type Hideouts {
 
 type ImpactSoundData {
   Id: string @unique
+  "Located in Audio/SoundEffects. Format has SG removed and $(#) replaced with the number"
   Sound: string
   _: i32
   _: i32
@@ -1954,7 +1971,7 @@ type ItemVisualIdentity {
   Id: string @unique
   DDSFile: string @file(ext: ".dds")
   AOFile: string @file(ext: ".ao")
-  SoundEffectsKey: SoundEffects
+  InventorySoundEffect: SoundEffects
   _: i32 @unique
   AOFile2: string @file(ext: ".ao")
   MarauderSMFiles: [string] @file(ext: ".sm")
@@ -2021,6 +2038,7 @@ type JobRaidBrackets {
 
 type KillstreakThresholds {
   Kills: i32
+  "Monster that plays the effect, i.e. the 'nova' etc."
   MonsterVarietiesKey: MonsterVarieties
   AchievementItemsKey: AchievementItems
 }
@@ -2137,7 +2155,9 @@ type MapInhabitants {
 
 type MapPins {
   Id: string @unique
+  "X starts at left side of image, can be negative"
   PositionX: i32
+  "Y starts at top side of image, can be negative"
   PositionY: i32
   Waypoint_WorldAreasKey: WorldAreas
   WorldAreasKeys: [WorldAreas]
@@ -2177,7 +2197,6 @@ type Maps {
   UpgradedFrom_MapsKey: Maps
   MapsKey2: Maps
   MapsKey3: Maps
-  
   "References MapSeries as an enum: i32, 1-based indexing"
   MapSeriesKey: i32
   _: bool
@@ -2827,6 +2846,7 @@ type MonsterVarieties {
   _: i32
   _: string
   _: string
+  "in percent"
   ModelSizeMultiplier: i32
   _: i32
   _: i32
@@ -2834,6 +2854,7 @@ type MonsterVarieties {
   _: i32
   _: i32
   TagsKeys: [Tags]
+  "in percent"
   ExperienceMultiplier: i32
   _: [i32]
   _: i32
@@ -2847,8 +2868,11 @@ type MonsterVarieties {
   Stance: string
   _: rid
   Name: string
+  "in percent"
   DamageMultiplier: i32
+  "in percent"
   LifeMultiplier: i32
+  "in ms"
   AttackSpeed: i32
   Weapon1_ItemVisualIdentityKeys: [ItemVisualIdentity]
   Weapon2_ItemVisualIdentityKeys: [ItemVisualIdentity]
@@ -3235,6 +3259,7 @@ type PassiveSkills {
   Stat2Value: i32
   Stat3Value: i32
   Stat4Value: i32
+  "Id used by PassiveSkillGraph.psg"
   PassiveSkillGraphId: i32 @unique
   Name: string
   CharactersKeys: [Characters]
@@ -3610,6 +3635,7 @@ type ShopPaymentPackage {
   _: string
   _: bool
   Upgrade_ShopPaymentPackageKey: ShopPaymentPackage
+  "Number of points the user gets back if they opt-out of physical items"
   PhysicalItemPoints: i32
   _: i32
   ShopPackagePlatformKeys: [i32]
@@ -3848,11 +3874,13 @@ type StrDexIntMissionExtraRequirement {
   SpawnWeight: i32
   MinLevel: i32
   MaxLevel: i32
+  "in milliseconds"
   TimeLimit: i32
   HasTimeBonusPerKill: bool
   HasTimeBonusPerObjectTagged: bool
   HasLimitedPortals: bool
   NPCTalkKey: NPCTalk
+  "in milliseconds"
   TimeLimitBonusFromObjective: i32
   ObjectCount: i32
   _: [i32]
@@ -4188,6 +4216,7 @@ enum WeaponSoundTypes { _ }
 type WeaponTypes {
   BaseItemTypesKey: BaseItemTypes @unique
   Critical: i32
+  "1000 / speed -> attacks per second"
   Speed: i32
   DamageMin: i32
   DamageMax: i32
@@ -4204,6 +4233,7 @@ type Words {
   SpawnWeight_Values: [u32]
   _: i32
   Text2: string
+  "the inflection identifier used for i18n in related fields"
   Inflection: string
 }
 
@@ -4243,6 +4273,7 @@ type WorldAreas {
   VaalArea_SpawnChance: i32
   Strongbox_SpawnChance: i32
   Strongbox_MaxCount: i32
+  "Normal/Magic/Rare/Unique spawn distribution"
   Strongbox_RarityWeight: [i32]
   _: i8
   _: i32

--- a/dat-schema/_Core.gql
+++ b/dat-schema/_Core.gql
@@ -456,7 +456,7 @@ type BaseItemTypes {
   Width: i32
   Height: i32
   Name: string
-  InheritsFrom: string
+  InheritsFrom: string @files(ext: [".ot", ".otc"])
   DropLevel: i32
   FlavourTextKey: FlavourText
   Implicit_ModsKeys: [Mods]
@@ -809,7 +809,7 @@ type Chests {
   CurrencyUse_AchievementItemsKey: AchievementItems
   Encounter_AchievementItemsKeys: [AchievementItems]
   _: rid
-  InheritsFrom: string
+  InheritsFrom: string @files(ext: [".ot", ".otc"])
   _: bool
   _: rid
 }
@@ -1191,7 +1191,7 @@ type ElderBossArenas {
 type ElderMapBossOverride {
   WorldAreasKey: WorldAreas @unique
   MonsterVarietiesKeys: [MonsterVarieties]
-  TerrainMetadata: string
+  TerrainMetadata: string @files(ext: [".ot", ".otc"])
 }
 
 type EndlessLedgeChests {
@@ -1280,7 +1280,7 @@ type ExecuteGEAL {
   _: i32
   _: bool
   _: i32
-  MetadataIDs: [string]
+  MetadataIDs: [string] @files(ext: [".ot", ".otc"])
   ScriptCommand: string
   _: i32
   _: i32
@@ -1401,6 +1401,8 @@ type FragmentStashTabLayout {
   SizeX: i32
   SizeY: i32
   _: i8
+  _: i32
+  _: i32
 }
 
 type GameConstants {
@@ -1757,7 +1759,7 @@ type HideoutDoodads {
   _: i32
   _: i32
   _: i32
-  InheritsFrom: string
+  InheritsFrom: string @files(ext: [".ot", ".otc"])
   IsCraftingBench: bool
   _: bool
 }
@@ -2110,7 +2112,7 @@ type MapDevices {
   _: rid
   _: i32
   _: i8
-  InheritsFrom: string
+  InheritsFrom: string @files(ext: [".ot", ".otc"])
   Command: string
   Command_Data: [i32]
 }
@@ -2381,7 +2383,7 @@ type MiscEffectPacks {
 
 type MiscObjects {
   Id: string @unique
-  EffectVirtualPath: string
+  EffectVirtualPath: string @files(ext: [".ot", ".otc"])
   PreloadGroupsKeys: [PreloadGroups]
   _: i32
   _: i32
@@ -2780,7 +2782,7 @@ enum MonsterSkillsTargets { _ }
 enum MonsterSkillsWaveDirection { _ }
 
 type MonsterSpawnerGroups {
-  Id: string
+  Id: string @files(ext: [".ot", ".otc"])
 }
 
 type MonsterSpawnerGroupsPerLevel {
@@ -2820,7 +2822,7 @@ type MonsterVarieties {
   MaximumAttackDistance: i32
   ACTFiles: [string] @file(ext: ".act")
   AOFiles: [string] @file(ext: ".ao")
-  BaseMonsterTypeIndex: string
+  BaseMonsterTypeIndex: string @files(ext: [".ot", ".otc"])
   ModsKeys: [Mods]
   _: i32
   _: string
@@ -3093,7 +3095,7 @@ type NPCMaster {
 type NPCs {
   Id: string @unique
   Name: string
-  Metadata: string
+  Metadata: string @files(ext: [".ot", ".otc"])
   _: i32
   NPCMasterKey: NPCMaster
   ShortName: string
@@ -3313,7 +3315,7 @@ type PCBangRewardMicros {
 enum PerLevelValues { _ }
 
 type Pet {
-  Id: string @unique
+  Id: string @unique @files(ext: [".ot", ".otc"])
   BaseItemTypesKey: BaseItemTypes
   _: i32
   _: i32
@@ -3341,7 +3343,7 @@ type PreloadGroups {
 enum PreloadPriorities { _ }
 
 type Projectiles {
-  Id: string @unique
+  Id: string @unique @files(ext: [".ot", ".otc"])
   AOFiles: [string] @file(ext: ".ao")
   LoopAnimationIds: [string]
   ImpactAnimationIds: [string]
@@ -3350,7 +3352,7 @@ type Projectiles {
   _: i32
   _: bool
   _: bool
-  InheritsFrom: string
+  InheritsFrom: string @files(ext: [".ot", ".otc"])
   _: i32
   _: rid
   _: i32
@@ -3535,7 +3537,7 @@ type RecipeUnlockDisplay {
 
 type RecipeUnlockObjects {
   WorldAreasKey: WorldAreas
-  InheritsFrom: string
+  InheritsFrom: string @files(ext: [".ot", ".otc"])
   RecipeId: i32
 }
 

--- a/dat-schema/_Core.gql
+++ b/dat-schema/_Core.gql
@@ -44,7 +44,7 @@ type AchievementSetRewards {
   Rewards: [BaseItemTypes]
   TotemPieceEveryNAchievements: i32
   Message: string
-  NotificationIcon: string
+  NotificationIcon: string @file(ext: ".dds")
   HideoutName: string
 }
 
@@ -60,7 +60,7 @@ type ActiveSkills {
   DisplayedName: string
   Description: string
   _: string
-  Icon_DDSFile: string
+  Icon_DDSFile: string @file(ext: ".dds")
   ActiveSkillTargetTypes: [u32]
   ActiveSkillTypes: [u32]
   WeaponRestriction_ItemClassesKeys: [ItemClasses]
@@ -80,7 +80,7 @@ type ActiveSkills {
   _: i32
   _: rid
   _: bool
-  AIFile: string
+  AIFile: string @file(ext: ".ai")
   _: i32
   _: i32
   _: bool
@@ -106,7 +106,7 @@ type AddBuffToTargetVarieties {
 type AdditionalLifeScaling {
   IntId: i32
   ID: string
-  DatFile: string
+  DatFile: string @file(ext: ".dat")
 }
 
 enum AdditionalLifeScalingPerLevel { _ }
@@ -129,9 +129,9 @@ type AdvancedSkillsTutorial {
   _: [rid]
   _: [rid]
   Description: string
-  International_BK2File: string
+  International_BK2File: string @file(ext: ".bk2")
   _: rid
-  China_BK2File: string
+  China_BK2File: string @file(ext: ".bk2")
   CharactersKey: [Characters]
 }
 
@@ -175,7 +175,7 @@ type AlternatePassiveSkills {
   RandomMin: i32
   RandomMax: i32
   FlavourText: string
-  DDSIcon: string
+  DDSIcon: string @file(ext: ".dds")
   AchievementItemsKeys: [AchievementItems]
   _: i32
   _: i32
@@ -227,7 +227,7 @@ type ArchetypeRewards {
   _: rid
   _: [rid]
   _: rid
-  BK2File: string
+  BK2File: string @file(ext: ".bk2")
 }
 
 type Archetypes {
@@ -237,7 +237,7 @@ type Archetypes {
   AscendancyClassName: string
   Description: string
   UIImageFile: string
-  TutorialVideo_BKFile: string
+  TutorialVideo_BKFile: string @file(ext: ".bk")
   _: i32
   _: f32
   _: f32
@@ -253,7 +253,7 @@ type AreaInfluenceDoodads {
   StatsKey: Stats
   StatValue: i32
   _: f32
-  AOFiles: [string]
+  AOFiles: [string] @file(ext: ".ao")
   _: i32
   _: i8
 }
@@ -310,7 +310,7 @@ type Ascendancy {
   RGBFlavourTextColour: string
   Name: string
   FlavourText: string
-  OGGFile: string
+  OGGFile: string @file(ext: ".ogg")
 }
 
 type AtlasAwakeningStats {
@@ -394,7 +394,7 @@ type AtlasNode {
   _: i32
   _: i32
   _: i32
-  DDSFile: string
+  DDSFile: string @file(ext: ".dds")
 }
 
 type AtlasNodeDefinition {
@@ -441,7 +441,7 @@ type AwardDisplay {
   _: string
   _: string
   ForegroundImage: string
-  OGGFile: string
+  OGGFile: string @file(ext: ".ogg")
   _: i32
 }
 
@@ -512,19 +512,19 @@ type BlightStashTabLayout {
 
 type BloodTypes {
   Id: string @unique
-  PETFile1: string
-  PETFile2: string
-  PETFile3: string
+  PETFile1: string @file(ext: ".pet")
+  PETFile2: string @file(ext: ".pet")
+  PETFile3: string @file(ext: ".pet")
   _: rid
-  PETFile4: string
-  PETFile5: string
-  PETFile6: string
+  PETFile4: string @file(ext: ".pet")
+  PETFile5: string @file(ext: ".pet")
+  PETFile6: string @file(ext: ".pet")
   _: rid
   _: [rid]
   _: rid
-  PETFile7: string
-  PETFile8: string
-  PETFile9: string
+  PETFile7: string @file(ext: ".pet")
+  PETFile8: string @file(ext: ".pet")
+  PETFile9: string @file(ext: ".pet")
 }
 
 enum BuffCategories { _ }
@@ -615,20 +615,20 @@ type BuffVisualOrbTypes {
 
 type BuffVisuals {
   Id: string @unique
-  BuffDDSFile: string
-  EPKFiles1: [string]
-  EPKFiles2: [string]
+  BuffDDSFile: string @file(ext: ".dds")
+  EPKFiles1: [string] @file(ext: ".epk")
+  EPKFiles2: [string] @file(ext: ".epk")
   MiscAnimatedKeys1: [MiscAnimated]
   _: bool
   BuffName: string
   _: rid
   _: rid
   BuffDescription: string
-  EPKFile: string
+  EPKFile: string @file(ext: ".epk")
   HasExtraArt: bool
   ExtraArt: string
   _: [i32]
-  EPKFiles: [string]
+  EPKFiles: [string] @file(ext: ".epk")
   _: [rid]
   _: i32
   _: i32
@@ -690,8 +690,8 @@ type CharacterPanelTabs {
 type Characters {
   Id: string @unique
   Name: string @unique
-  AOFile: string
-  ACTFile: string
+  AOFile: string @file(ext: ".ao")
+  ACTFile: string @file(ext: ".act")
   BaseMaxLife: i32
   BaseMaxMana: i32
   WeaponSpeed: i32
@@ -711,7 +711,7 @@ type Characters {
   _: i32
   _: i32
   CharacterSize: i32
-  IntroSoundFile: string
+  IntroSoundFile: string @file(ext: ".ogg")
   StartWeapon_BaseItemTypesKey: BaseItemTypes
   _: i32
   TraitDescription: string
@@ -755,7 +755,7 @@ type CharacterStartStateSet {
 type CharacterTextAudio {
   Id: string @unique
   Text: string
-  SoundFile: string
+  SoundFile: string @file(ext: ".ogg")
 }
 
 type ChestClusters {
@@ -769,18 +769,18 @@ type ChestClusters {
 
 type ChestEffects {
   Id: string @unique
-  Normal_EPKFile: string
-  Normal_Closed_AOFile: string
-  Normal_Open_AOFile: string
-  Magic_EPKFile: string
-  Unique_EPKFile: string
-  Rare_EPKFile: string
-  Magic_Closed_AOFile: string
-  Unique_Closed_AOFile: string
-  Rare_Closed_AOFile: string
-  Magic_Open_AOFile: string
-  Unique_Open_AOFile: string
-  Rare_Open_AOFile: string
+  Normal_EPKFile: string @file(ext: ".epk")
+  Normal_Closed_AOFile: string @file(ext: ".ao")
+  Normal_Open_AOFile: string @file(ext: ".ao")
+  Magic_EPKFile: string @file(ext: ".epk")
+  Unique_EPKFile: string @file(ext: ".epk")
+  Rare_EPKFile: string @file(ext: ".epk")
+  Magic_Closed_AOFile: string @file(ext: ".ao")
+  Unique_Closed_AOFile: string @file(ext: ".ao")
+  Rare_Closed_AOFile: string @file(ext: ".ao")
+  Magic_Open_AOFile: string @file(ext: ".ao")
+  Unique_Open_AOFile: string @file(ext: ".ao")
+  Rare_Open_AOFile: string @file(ext: ".ao")
 }
 
 type Chests {
@@ -788,7 +788,7 @@ type Chests {
   _: bool
   _: i32
   Name: string
-  AOFiles: [string]
+  AOFiles: [string] @file(ext: ".ao")
   _: bool
   _: bool
   _: i32
@@ -981,7 +981,7 @@ type DamageHitEffects {
 type DamageParticleEffects {
   DamageParticleEffectTypes: DamageParticleEffectTypes
   Variation: i32
-  PETFile: string
+  PETFile: string @file(ext: ".pet")
   _: rid
   _: rid
   _: i32
@@ -1109,7 +1109,7 @@ type Doors {
 
 type DropEffects {
   Id: string @unique
-  AOFile: string
+  AOFile: string @file(ext: ".ao")
 }
 
 type DropPool {
@@ -1203,8 +1203,8 @@ type EndlessLedgeChests {
 
 type Environments {
   Id: string @unique
-  Base_ENVFile: string
-  Corrupted_ENVFile: string
+  Base_ENVFile: string @file(ext: ".env")
+  Corrupted_ENVFile: string @file(ext: ".env")
   _: i32
   _: i32
   _: i32
@@ -1215,7 +1215,7 @@ type Environments {
 
 type EnvironmentTransitions {
   Id: string
-  OTFiles: [string]
+  OTFiles: [string] @file(ext: ".ot")
   _: [string]
 }
 
@@ -1383,8 +1383,8 @@ enum FlavourTextImages { _ }
 
 type Footprints {
   Id: string @unique
-  Active_AOFiles: [string]
-  Idle_AOFiles: [string]
+  Active_AOFiles: [string] @file(ext: ".ao")
+  Idle_AOFiles: [string] @file(ext: ".ao")
 }
 
 type FootstepAudio {
@@ -1487,7 +1487,7 @@ type GeometryChannel {
   _: bool
   _: rid
   _: rid
-  EPKFile: string
+  EPKFile: string @file(ext: ".epk")
   _: i32
   _: i32
 }
@@ -1569,8 +1569,8 @@ type GlobalAudioConfig {
 
 type Grandmasters {
   Id: string
-  GMFile: string
-  AISFile: string
+  GMFile: string @file(ext: ".gm")
+  AISFile: string @file(ext: ".ais")
   ModsKeys: [Mods]
   CharacterLevel: i32
   _: bool
@@ -1691,7 +1691,7 @@ type GroundEffects {
   _: i32
   _: bool
   _: bool
-  AOFile: string
+  AOFile: string @file(ext: ".ao")
   _: bool
   _: [i32]
   _: [i32]
@@ -1749,7 +1749,7 @@ type HeistStorageLayout {
 
 type HideoutDoodads {
   BaseItemTypesKey: BaseItemTypes @unique
-  Variation_AOFiles: [string]
+  Variation_AOFiles: [string] @file(ext: ".ao")
   FavourCost: i32
   MasterLevel: i32
   HideoutNPCsKey: HideoutNPCs
@@ -1784,7 +1784,7 @@ type Hideouts {
   Id: string @unique
   SmallWorldAreasKey: WorldAreas
   _: i32
-  HideoutFile: string
+  HideoutFile: string @file(ext: ".hideout")
   _: [rid]
   LargeWorldAreasKey: WorldAreas
   HideoutImage: string
@@ -1915,19 +1915,19 @@ type ItemThemes {
 
 type ItemVisualEffect {
   Id: string @unique
-  DaggerEPKFile: string
-  BowEPKFile: string
-  OneHandedMaceEPKFile: string
-  OneHandedSwordEPKFile: string
+  DaggerEPKFile: string @file(ext: ".epk")
+  BowEPKFile: string @file(ext: ".epk")
+  OneHandedMaceEPKFile: string @file(ext: ".epk")
+  OneHandedSwordEPKFile: string @file(ext: ".epk")
   _: string
-  TwoHandedSwordEPKFile: string
-  TwoHandedStaffEPKFile: string
+  TwoHandedSwordEPKFile: string @file(ext: ".epk")
+  TwoHandedStaffEPKFile: string @file(ext: ".epk")
   _: i32 @unique
-  TwoHandedMaceEPKFile: string
-  OneHandedAxeEPKFile: string
-  TwoHandedAxeEPKFile: string
-  ClawEPKFile: string
-  PETFile: string
+  TwoHandedMaceEPKFile: string @file(ext: ".epk")
+  OneHandedAxeEPKFile: string @file(ext: ".epk")
+  TwoHandedAxeEPKFile: string @file(ext: ".epk")
+  ClawEPKFile: string @file(ext: ".epk")
+  PETFile: string @file(ext: ".pet")
 }
 
 type ItemVisualHeldBodyModel {
@@ -1950,18 +1950,18 @@ type ItemVisualHeldBodyModel {
 
 type ItemVisualIdentity {
   Id: string @unique
-  DDSFile: string
-  AOFile: string
+  DDSFile: string @file(ext: ".dds")
+  AOFile: string @file(ext: ".ao")
   SoundEffectsKey: SoundEffects
   _: i32 @unique
-  AOFile2: string
-  MarauderSMFiles: [string]
-  RangerSMFiles: [string]
-  WitchSMFiles: [string]
-  DuelistDexSMFiles: [string]
-  TemplarSMFiles: [string]
-  ShadowSMFiles: [string]
-  ScionSMFiles: [string]
+  AOFile2: string @file(ext: ".ao")
+  MarauderSMFiles: [string] @file(ext: ".sm")
+  RangerSMFiles: [string] @file(ext: ".sm")
+  WitchSMFiles: [string] @file(ext: ".sm")
+  DuelistDexSMFiles: [string] @file(ext: ".sm")
+  TemplarSMFiles: [string] @file(ext: ".sm")
+  ShadowSMFiles: [string] @file(ext: ".sm")
+  ScionSMFiles: [string] @file(ext: ".sm")
   MarauderShape: string
   RangerShape: string
   WitchShape: string
@@ -1972,9 +1972,9 @@ type ItemVisualIdentity {
   _: i32
   _: i32
   Pickup_AchievementItemsKeys: [AchievementItems]
-  SMFiles: [string]
+  SMFiles: [string] @file(ext: ".sm")
   Identify_AchievementItemsKeys: [AchievementItems]
-  EPKFile: string
+  EPKFile: string @file(ext: ".epk")
   Corrupt_AchievementItemsKeys: [AchievementItems]
   IsAlternateArt: bool
   _: bool
@@ -2185,11 +2185,11 @@ type Maps {
 type MapSeries {
   Id: string @unique
   Name: string
-  BaseIcon_DDSFile: string
-  Infected_DDSFile: string
-  Shaper_DDSFile: string
-  Elder_DDSFile: string
-  Drawn_DDSFile: string
+  BaseIcon_DDSFile: string @file(ext: ".dds")
+  Infected_DDSFile: string @file(ext: ".dds")
+  Shaper_DDSFile: string @file(ext: ".dds")
+  Elder_DDSFile: string @file(ext: ".dds")
+  Drawn_DDSFile: string @file(ext: ".dds")
 }
 
 type MapSeriesTiers {
@@ -2245,19 +2245,19 @@ type Melee {
   MeleeTrailsKey6: MeleeTrails
   MeleeTrailsKey7: MeleeTrails
   _: i8
-  SurgeEffect_EPKFile: string
+  SurgeEffect_EPKFile: string @file(ext: ".epk")
   _: string
   _: string
 }
 
 type MeleeTrails {
-  EPKFile1: string
-  EPKFile2: string
+  EPKFile1: string @file(ext: ".epk")
+  EPKFile2: string @file(ext: ".epk")
   _: i32
   _: i32
   _: i32
   _: bool
-  AOFile: string
+  AOFile: string @file(ext: ".ao")
   _: bool
 }
 
@@ -2289,7 +2289,7 @@ type MicrotransactionCombineFormula {
   Id: string
   Result_BaseItemTypesKey: BaseItemTypes
   Ingredients_BaseItemTypesKeys: [BaseItemTypes]
-  BK2File: string
+  BK2File: string @file(ext: ".bk2")
   _: [i32]
   _: i32
   _: i8
@@ -2297,20 +2297,20 @@ type MicrotransactionCombineFormula {
 
 type MicrotransactionFireworksVariations {
   BaseItemTypesKey: BaseItemTypes
-  AOFile: string
+  AOFile: string @file(ext: ".ao")
   _: bool
 }
 
 type MicrotransactionPeriodicCharacterEffectVariations {
   Id: string @unique
-  AOFile: string
+  AOFile: string @file(ext: ".ao")
   _: rid
 }
 
 type MicrotransactionPortalVariations {
   BaseItemTypesKey: BaseItemTypes
-  AOFile: string
-  MapAOFile: string
+  AOFile: string @file(ext: ".ao")
+  MapAOFile: string @file(ext: ".ao")
   _: f32
   _: rid
 }
@@ -2338,7 +2338,7 @@ enum MicrotransactionSlotId { _ }
 type MicrotransactionSocialFrameVariations {
   Id: i32 @unique
   BaseItemTypesKey: BaseItemTypes
-  BK2File: string
+  BK2File: string @file(ext: ".bk2")
 }
 
 type MinimapIcons {
@@ -2354,7 +2354,7 @@ type MinimapIcons {
 
 type MiscAnimated {
   Id: string @unique
-  AOFile: string
+  AOFile: string @file(ext: ".ao")
   PreloadGroupsKeys: [PreloadGroups]
   _: i32
   _: i32
@@ -2370,13 +2370,13 @@ type MiscBeams {
 
 type MiscEffectPacks {
   Id: string @unique
-  EPKFile: string
+  EPKFile: string @file(ext: ".epk")
   _: i32
   _: i32
   _: i32
   _: [rid]
   _: i8
-  PlayerOnly_EPKFile: string
+  PlayerOnly_EPKFile: string @file(ext: ".epk")
 }
 
 type MiscObjects {
@@ -2402,7 +2402,7 @@ type MissionTimerTypes {
 
 type MissionTransitionTiles {
   Id: string @unique
-  TDTFile: string
+  TDTFile: string @file(ext: ".tdt")
   _: i32
   _: i32
   _: i32
@@ -2527,7 +2527,7 @@ type ModType {
 
 type MonsterArmours {
   Id: string
-  ArtString_SMFile: string
+  ArtString_SMFile: string @file(ext: ".sm")
 }
 
 enum MonsterBehavior { _ }
@@ -2818,8 +2818,8 @@ type MonsterVarieties {
   ObjectSize: i32
   MinimumAttackDistance: i32
   MaximumAttackDistance: i32
-  ACTFiles: [string]
-  AOFiles: [string]
+  ACTFiles: [string] @file(ext: ".act")
+  AOFiles: [string] @file(ext: ".ao")
   BaseMonsterTypeIndex: string
   ModsKeys: [Mods]
   _: i32
@@ -2840,7 +2840,7 @@ type MonsterVarieties {
   CriticalStrikeChance: i32
   _: i32
   GrantedEffectsKeys: [GrantedEffects]
-  AISFile: string
+  AISFile: string @file(ext: ".ais")
   ModsKeys2: [Mods]
   Stance: string
   _: rid
@@ -2881,7 +2881,7 @@ type MonsterVarieties {
   _: [rid]
   _: [rid]
   _: i32
-  SinkAnimation_AOFile: string
+  SinkAnimation_AOFile: string @file(ext: ".ao")
   _: bool
   _: [rid]
   _: bool
@@ -2964,8 +2964,8 @@ type MultiPartAchievements {
 
 type Music {
   Id: string @unique
-  SoundFile: string
-  BankFile: string
+  SoundFile: string @file(ext: ".ogg")
+  BankFile: string @file(ext: ".bank")
   _: i32
   IsAvailableInHideout: i8
   Name: string
@@ -2982,7 +2982,7 @@ type MusicCategories {
 
 type MysteryBoxes {
   BaseItemTypesKey: BaseItemTypes
-  BK2File: string
+  BK2File: string @file(ext: ".bk2")
   BoxId: string
   BundleId: string
 }
@@ -3169,8 +3169,8 @@ type NPCTextAudio {
   Id: string @unique
   CharactersKey: Characters
   Text: string
-  Mono_AudioFile: string
-  Stereo_AudioFile: string
+  Mono_AudioFile: string @file(ext: ".ogg")
+  Stereo_AudioFile: string @file(ext: ".ogg")
   HasStereo: bool
   _: bool
   Video: string
@@ -3227,7 +3227,7 @@ type PassiveSkillFilterOptions {
 
 type PassiveSkills {
   Id: string @unique
-  Icon_DDSFile: string
+  Icon_DDSFile: string @file(ext: ".dds")
   StatsKeys: [Stats]
   Stat1Value: i32
   Stat2Value: i32
@@ -3342,7 +3342,7 @@ enum PreloadPriorities { _ }
 
 type Projectiles {
   Id: string @unique
-  AOFiles: [string]
+  AOFiles: [string] @file(ext: ".ao")
   LoopAnimationIds: [string]
   ImpactAnimationIds: [string]
   ProjectileSpeed: i32
@@ -3356,8 +3356,8 @@ type Projectiles {
   _: i32
   _: bool
   _: bool
-  Stuck_AOFile: string
-  Bounce_AOFile: string
+  Stuck_AOFile: string @file(ext: ".ao")
+  Bounce_AOFile: string @file(ext: ".ao")
   _: i32
   _: i32
   _: i32
@@ -3385,7 +3385,7 @@ type Quest {
   Id: string @unique
   Act: i32
   Name: string @localized
-  Icon_DDSFile: string
+  Icon_DDSFile: string @file(ext: ".dds")
   QuestId: i32
   _: bool
   _: rid
@@ -3571,7 +3571,7 @@ type ShieldTypes {
 type ShopCategory {
   Id: string @unique
   ClientText: string
-  ClientJPGFile: string
+  ClientJPGFile: string @file(ext: ".jpg")
   WebsiteText: string
   WebsiteJPGFile: string
   _: i32
@@ -3636,7 +3636,7 @@ type SigilDisplay {
   Id: string @unique
   Active_StatsKey: Stats
   Inactive_StatsKey: Stats
-  DDSFile: string
+  DDSFile: string @file(ext: ".dds")
   Inactive_ArtFile: string
   Active_ArtFile: string
   Frame_ArtFile: string
@@ -3682,7 +3682,7 @@ type SkillMineVariations {
 type SkillMorphDisplay {
   _: rid
   _: [rid]
-  DDSFiles: [string]
+  DDSFiles: [string] @file(ext: ".dds")
   _: i32
   _: [i32]
   _: i32
@@ -3728,8 +3728,8 @@ type SkillTrapVariations {
 
 type SoundEffects {
   Id: string @unique
-  SoundFile: string
-  SoundFile_2D: string
+  SoundFile: string @file(ext: ".ogg")
+  SoundFile_2D: string @file(ext: ".ogg")
   _: bool
 }
 
@@ -3762,12 +3762,12 @@ type SpawnObject {
 
 type SpecialRooms {
   Id: string @unique
-  ARMFile: string
+  ARMFile: string @file(ext: ".arm")
 }
 
 type SpecialTiles {
   Id: string @unique
-  TDTFile: string
+  TDTFile: string @file(ext: ".tdt")
 }
 
 type SpectreOverrides {
@@ -4005,7 +4005,7 @@ type Tips {
 
 type Topologies {
   Id: string @unique
-  DGRFile: string
+  DGRFile: string @file(ext: ".dgr")
   _: i32
   _: i32
   _: i32
@@ -4054,7 +4054,7 @@ type TriggerSpawners {
 
 type Tutorial {
   Id: string @unique
-  UIFile: string
+  UIFile: string @file(ext: ".ui")
   _: rid
   IsEnabled: bool
   _: i32
@@ -4071,7 +4071,7 @@ enum UITalkCategories { _ }
 type UITalkText {
   Id: string @unique
   UITalkCategoriesKey: UITalkCategories
-  OGGFile: string
+  OGGFile: string @file(ext: ".ogg")
   Text: string
   _: i8
   _: rid
@@ -4216,7 +4216,7 @@ type WorldAreas {
   _: i32
   _: i32
   _: i32
-  LoadingScreen_DDSFile: string
+  LoadingScreen_DDSFile: string @file(ext: ".dds")
   _: i32
   _: [i32]
   _: i32
@@ -4269,7 +4269,7 @@ type WorldAreas {
   _: i32
   _: i32
   _: i32
-  TSIFile: string
+  TSIFile: string @file(ext: ".tsi")
   _: rid
   _: i32
   _: i32


### PR DESCRIPTION
- Where PyPoE had file_ext, I added `@file(ext: "...")`.
- For PyPoE's file_path without file_ext, I checked the data to see if it actually made sense. A bunch of them were sprite references (to Art/UIImages1.txt), which I did not convert. The ones I took over were mostly metadata paths, so `@files(ext: [".ot", ".otc"])`.
- I only converted PyPoE's descriptions where I felt they were actually useful. But I'm not entirely sure about how to best handle them, might still be too many.