### PR TITLE
Add to the item classes spec

### DIFF
--- a/dat-schema/_Core.gql
+++ b/dat-schema/_Core.gql
@@ -2182,7 +2182,7 @@ enum ItemClassFlags @indexing(first: 0) {
   MELEE
   OFF_HAND
   FLASK
-  ARMOR
+  ARMOUR
   JEWELLERY
   CURRENCY
 }

--- a/dat-schema/_Core.gql
+++ b/dat-schema/_Core.gql
@@ -2166,13 +2166,13 @@ type ItemClasses {
   CanTransferSkin: bool
   ItemStance: ItemStances
   CanScourge: bool
-  UpgradeRarityWhenScourged: bool
+  CanUpgradeRarity: bool # by using Tainted Mythic Orb
   _: bool # 3.17
   _: bool # 3.18
   MaxInventoryDimensions: [i32]
   Flags: [ItemClassFlags]
   IsUnmodifiable: bool
-  CanBeFractured: bool # 3.19
+  CanBeFractured: bool
   EquipAchievements: AchievementItems
 }
 

--- a/dat-schema/_Core.gql
+++ b/dat-schema/_Core.gql
@@ -2166,17 +2166,26 @@ type ItemClasses {
   CanTransferSkin: bool
   ItemStance: ItemStances
   CanScourge: bool
-  _: bool # CanScourge2
+  UpgradeRarityWhenScourged: bool
   _: bool # 3.17
   _: bool # 3.18
-  _: [i32]
+  MaxInventoryDimensions: [i32]
   Flags: [ItemClassFlags]
-  _: bool
-  _: bool # 3.19
+  IsUnmodifiable: bool
+  CanBeFractured: bool # 3.19
   EquipAchievements: AchievementItems
 }
 
-enum ItemClassFlags @indexing(first: 0) { _ }
+enum ItemClassFlags @indexing(first: 0) {
+  WEAPON
+  ONE_HAND
+  MELEE
+  OFF_HAND
+  FLASK
+  ARMOR
+  JEWELLERY
+  CURRENCY
+}
 
 type ItemCostPerLevel {
   Contract_BaseItemTypesKey: BaseItemTypes


### PR DESCRIPTION
Uncertainty notes:

- `UpgradeRarityWhenScourged`...maps are the only class with a difference, and they didn't become rare when baked in the crucible.
- It's either `MaxInventoryDimensions` or `DefaultInventoryDimensions`. I went with the former based on Sanctum relics being `[4, 4]`. I have no explanation for Hybrid Flasks being `[3, 2]`.
- `CanBeFractured` makes sense based on its addition alongside drop conversion.