### PR TITLE
some Hideouts observations

### DIFF
--- a/dat-schema/_Core.gql
+++ b/dat-schema/_Core.gql
@@ -2086,13 +2086,13 @@ type Hideouts {
   SmallWorldAreasKey: WorldAreas
   HASH16: i32
   HideoutFile: string @file(ext: ".hideout")
-  _: [rid]
+  SpawnWorldAreasKeys: [WorldAreas]
   LargeWorldAreasKey: WorldAreas
   HideoutImage: string
   IsEnabled: bool
   Weight: i32
   _: HideoutRarity
-  _: bool
+  NotActsArea: bool
   Name: string
   _: [i32]
   _: bool

--- a/dat-schema/_Core.gql
+++ b/dat-schema/_Core.gql
@@ -2083,15 +2083,15 @@ type HideoutRarity {
 
 type Hideouts {
   Id: string @unique
-  SmallWorldAreasKey: WorldAreas
+  HideoutArea: WorldAreas
   HASH16: i32
   HideoutFile: string @file(ext: ".hideout")
-  SpawnWorldAreasKeys: [WorldAreas]
-  LargeWorldAreasKey: WorldAreas
+  SpawnAreas: [WorldAreas]
+  ClaimSideArea: WorldAreas
   HideoutImage: string
   IsEnabled: bool
   Weight: i32
-  _: HideoutRarity
+  Rarity: HideoutRarity
   NotActsArea: bool
   Name: string
   _: [i32]


### PR DESCRIPTION
Two columns that I'm reasonably sure of are included in this PR:
* `SpawnWorldAreasKeys` is a list of WorldAreas where the hideout spawns.
* Unknown11 is `false` for all hideouts where the area to unlock them is in a story Act (1-10, not counting the Epilogue), and `true` for all other hideouts. I've called this value `NotActsArea`. The Cartographer's Hideout, which is a free unlock when you reach the Epilogue, has `true` here.

Some other observations that I'm less confident about that I'm not currently including:
* There are 7 hideouts in the table that are unreleased:
  * Ancestral Hideout
  * Black Void Hideout
  * Cataclysmic Hideout
  * Chiyou Hideout
  * Humanoid Pet Hideout
  * Synthesis Hideout
  * Yaochi Hideout
* Aside from unreleased hideouts, `Unknown17` is `true` for all MTX hideouts and `false` otherwise. This could be `IsMTX`.
  * Black Void and Cataclysmic have `false`, and the rest of the unreleased have `true`.
* The only released hideout with `true` in `Unknown14` is the Ritualist's Hideout, which is also the only hideout that was a challenge reward. This could be `IsChallengeReward`.
  * Ancestral and Synthesis have `false`, and the rest of the unreleased have `true`.
  * ![image](https://user-images.githubusercontent.com/4292308/220363860-52b96df9-2c42-4041-b312-56ee6aac466b.png)

* `IsEnabled` is only `false` for the Ancestral and Synthesis hideouts. It's `true` for the rest of the unreleased hideouts, and `true` for all of the released hideouts.

You can see a more visual breakdown of these observations [here](https://docs.google.com/spreadsheets/d/1it7LN07AU4VwhcSR6LiPgIwtekoWo6kQKx5jzyHHtZU/edit?usp=sharing).