### PR TITLE
NPCTalk QuestKey -> QuestRewardOffersKey

### DIFF
--- a/dat-schema/_Core.gql
+++ b/dat-schema/_Core.gql
@@ -3768,7 +3768,7 @@ type NPCTalk {
   Script: string
   _: rid
   _: NPCTalkCategory
-  QuestKey: Quest
+  QuestRewardOffersKey: QuestRewardOffers
   QuestFlag: QuestFlags
   NPCTextAudioKeys: [NPCTextAudio]
   Script2: string


### PR DESCRIPTION
`QuestKey` in `NPCTalk` instead refers to `QuestRewardOffers` associating an NPC dialogue option with a set of quest rewards

See [quests.json](https://github.com/HeartofPhos/exile-leveling/blob/ff66ab9c757e05583926f40695eaa2c8a0f8e2bc/common/data/json/quests.json) where I've used it to display an NPC's name when handing in a specific reward offer