### PR TITLE
Update CurrencyItems and NPCs

### DIFF
--- a/dat-schema/_Core.gql
+++ b/dat-schema/_Core.gql
@@ -1160,6 +1160,7 @@ type CurrencyItems {
   ShopTag: ShopTag
   IsHardmode: bool
   DescriptionHardmode: string
+  IsGold: bool
 }
 
 type CurrencyStashTabLayout {
@@ -3748,6 +3749,7 @@ type NPCs {
   DialogueStyle: NPCDialogueStyles
   _: bool
   _: rid
+  Gender: string
 }
 
 type NPCShop {


### PR DESCRIPTION
In NPCs, it looks like a string field for Gender was added, containing M or F.

In CurrencyItems, a new bool field was added. It seems to be false for every row except what looks like Gold in the latest row, so IsGold seems a good enough guess for now.