### PR TITLE
unique stash visibility

### DIFF
--- a/dat-schema/_Core.gql
+++ b/dat-schema/_Core.gql
@@ -5103,8 +5103,8 @@ type UniqueStashLayout {
   _: i32
   OverrideWidth: i32
   OverrideHeight: i32
-  _: bool
-  ShowIfEmpty: bool
+  ShowIfEmptyChallengeLeague: bool
+  ShowIfEmptyStandard: bool
   RenamedVersion: UniqueStashLayout
   BaseVersion: UniqueStashLayout
   IsAlternateArt: bool
@@ -5118,9 +5118,9 @@ type UniqueStashTypes {
   _: i32
   _: i32
   Name: string @localized
-  _: i32
+  StandardCount: i32
   Image: string
-  _: i32
+  ChallengeLeagueCount: i32
   IsDisabled: bool
 }
 


### PR DESCRIPTION
## UniqueStashLayout

`Unknown8` and `ShowIfEmpty` differ in only 6 places:

* The Winds of Fate
* The Balance of Terror
* Sandstorm Visage
* Eternal Damnation
* Original Sin
* Eldritch Knowledge

The first 5 of these are Sanctum-exclusive uniques, where `Unknown8` is `true` and `ShowIfEmpty` is `false`. In-game, empty Unique Collection Tab slots for these items are shown in Sanctum league and Hidden in Standard

For Eldritch Knowledge, `Unknown8` is `false` and `ShowIfEmpty` is `true`. This slot is hidden in Sanctum and visible in Standard. Eldritch Knowledge is no longer obtainable as of 3.20, so this is probably an oversight and both columns should probably be false.

Accordingly, I've named `Unknown8` `ShowIfEmptyChallengeLeague` and renamed `ShowIfEmpty` to `ShowIfEmptyStandard`.

## UniqueStashTypes

`Unknown8` and `Unknown10` are `StandardCount` and `ChallengeLeagueCount`, i.e., the total number of non-hidden Unique Stash slots for each type. They differ from each other in only 4 places:

* Amulet
* Ring
* Staff
* Helmet

These correspond to Eternal Damnation, Original Sin, The Winds of Fate, and Sandstorm Visage, respectively. For Jewels, The Balance of Terror and Eldritch Knowledge cancel each other out since they are hidden in opposite places.

You can count in-game to see that there are indeed 104 jewels, 31 maps, etc, shown by default in the Uniques tab.