### PR TITLE
Repair LeagueInfo type

### DIFF
--- a/dat-schema/_Core.gql
+++ b/dat-schema/_Core.gql
@@ -2443,12 +2443,12 @@ type LeagueFlag {
 enum LeagueFlags @indexing(first: 0) { _ }
 
 type LeagueInfo {
-  Id: string @unique
+  LeagueNumber: rid
+  InfoClass: string
   PanelImage: string
   HeaderImage: string
   Screenshots: [string]
   Description: string
-  League: string
   _: bool
   TrailerVideoLink: string
   BackgroundImage: string

--- a/dat-schema/_Core.gql
+++ b/dat-schema/_Core.gql
@@ -2443,8 +2443,8 @@ type LeagueFlag {
 enum LeagueFlags @indexing(first: 0) { _ }
 
 type LeagueInfo {
-  LeagueNumber: rid
-  InfoClass: string
+  PanelVersion: LeagueInfoPanelVersions
+  PanelId: string
   PanelImage: string
   HeaderImage: string
   Screenshots: [string]
@@ -2455,6 +2455,10 @@ type LeagueInfo {
   _: bool
   _: bool
   PanelItems: [string]
+}
+
+type LeagueInfoPanelVersions {
+  Id: string
 }
 
 type LeagueProgressQuestFlags {


### PR DESCRIPTION
`LeagueInfo.dat64` (in the current state of the game) does not contain a unique identifying string at the start of its row data. This updates `type LeagueInfo` so that it is valid again.