### PR TITLE
Defined column in ItemVisualIdentity.dat

### DIFF
--- a/dat-schema/_Core.gql
+++ b/dat-schema/_Core.gql
@@ -2381,7 +2381,8 @@ type ItemVisualIdentity {
   _: bool
   _: [rid]
   _: string
-  _: i32
+  "0: Standard, 1: Flask, 2: Divination Card, 3: Gem"
+  Composition: i32
   _: rid
   _: rid
   _: rid


### PR DESCRIPTION
This column in ItemVisualIdentity.dat seems to indicate how the item's inventory icons or other visuals are composed.

- A value 0 is standard/non-specific
- A value of 1 is used for flasks and some flask skins that have icons made up of three segments layered on top of each other
- A value of 2 is used for divination cards
- A value of 3 is used for gems, which have icons made up of two segments layered on top of each other