### PR TITLE
Defined column in BestiaryRecipes.dat

### DIFF
--- a/dat-schema/3_02_Bestiary.gql
+++ b/dat-schema/3_02_Bestiary.gql
@@ -94,7 +94,8 @@ type BestiaryRecipes @tags(list: ["item:recipe", "crafting"]) {
   _: bool
   _: i32
   _: i32
-  _: i32
+  "1: Normal, 2: Ruthless"
+  GameMode: i32
   FlaskMod: Mods
 }
 


### PR DESCRIPTION
This column in BestiaryRecipes.dat appears to specify in which game mode the recipe is available.

- 1 is the normal game mode
- 2 is Ruthless mode