### PR TITLE
add MapSeries column for purple-tier maps

### DIFF
--- a/dat-schema/_Core.gql
+++ b/dat-schema/_Core.gql
@@ -2635,6 +2635,7 @@ type MapSeries {
   Drawn_DDSFile: string @file(ext: ".dds")
   Delirious_DDSFile: string @file(ext: ".dds")
   UberBlight_DDSFile: string @file(ext: ".dds")
+  Purple_DDSFile: string @file(ext: ".dds")
 }
 
 type MapSeriesTiers {


### PR DESCRIPTION
The purple map base plate for T17 maps was added in 3.23 Affliction for Valdo's Puzzle Box foiled maps and is reused for the five new T17 maps in 3.24 Necropolis.