### PR TITLE
Add an http server, containerize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 dist/
 schema.min.json
 schema.jsonl
+output/
 
 # Logs
 logs

--- a/Dockerfile.generate
+++ b/Dockerfile.generate
@@ -1,0 +1,16 @@
+FROM node:alpine
+
+WORKDIR /app
+
+COPY package.json .
+
+RUN npm install \
+ && npm install typescript -g \
+ && mkdir /output /dat-schema
+
+COPY tsconfig.json .
+COPY src/ src/
+
+RUN tsc
+
+CMD [ "npm", "run", "generate", "/dat-schema/", "/output/"]

--- a/Dockerfile.serve
+++ b/Dockerfile.serve
@@ -1,0 +1,16 @@
+FROM node:alpine
+
+WORKDIR /app
+
+COPY package.json .
+
+RUN npm install \
+ && npm install typescript -g \
+ && mkdir /dat-schema
+
+COPY tsconfig.json .
+COPY src/ src/
+
+RUN tsc
+
+CMD [ "npm", "run", "serve", "/dat-schema/"]

--- a/bin/build
+++ b/bin/build
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+cd "$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"..
+
+docker build -f Dockerfile.generate -t dat-schema-generate:latest
+docker build -f Dockerfile.serve -t dat-schema-serve:latest

--- a/bin/generate
+++ b/bin/generate
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+cd "$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"..
+
+mkdir -p output/
+docker run --rm -it -v ./dat-schema/:/dat-schema/:Z -v ./output:/output:Z dat-schema-generate:latest

--- a/bin/serve
+++ b/bin/serve
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+cd "$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"..
+
+docker run --rm -it -p 3001:3001 -v ./dat-schema/:/dat-schema/:Z dat-schema-serve:latest

--- a/dat-schema/_Core.gql
+++ b/dat-schema/_Core.gql
@@ -1695,7 +1695,11 @@ type GemTags {
   Stat4: Stats
 }
 
-enum GemTypes @indexing(first: 0) { _ }
+enum GemTypes @indexing(first: 0) {
+  SKILL
+  SUPPORT
+  SPIRIT
+}
 
 type GenericBuffAuras {
   Id: string @unique

--- a/dat-schema/poe2/_Core.gql
+++ b/dat-schema/poe2/_Core.gql
@@ -130,7 +130,6 @@ type BaseItemTypes @tags(list: ["item:def", "item:droptable"]) {
   _: rid # all nulls
 }
 
-
 type Chanceableitemclasses {
   ItemClass: ItemClasses
   _: i32
@@ -177,7 +176,6 @@ type CurrencyItems @tags(list: ["item:def", "item:recipe"]) {
   UsageHint: string
   _: bool
 }
-
 
 type EndgameCorruptionMods {
   _: rid
@@ -474,7 +472,7 @@ type SkillGems @tags(list: ["item:def"]) {
   VaalVariant_BaseItemTypesKey: BaseItemTypes
   IsVaalVariant: bool
   MinionGlobalSkillLevelStat: Stats
-  GemType: i32
+  GemType: GemTypes
   _: bool
   _: bool
   _: rid
@@ -504,9 +502,8 @@ type SkillGemSupports {
 type SupportGems {
   SkillGemsKey: SkillGems
   _: i32
-  Icon: string  @file(ext: ".dds")
+  Icon: string @file(ext: ".dds")
 }
-
 
 type Tags {
   Id: string @unique
@@ -522,7 +519,6 @@ type UncutGemAdditionalTiers {
   Tier: i32
   Odds: i32
 }
-
 
 type UncutGemTiers {
   BaseItemType: BaseItemTypes
@@ -1096,7 +1092,7 @@ type UtilityFlaskBuffs {
   BuffDefinitionsKey: BuffDefinitions
   StatValues: [i32]
   StatValues2: [i32]
-  _: rid  
+  _: rid
 }
 
 type WeaponClasses {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pathofexile-dat-schema",
-  "version": "6.0.1",
+  "version": "7.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pathofexile-dat-schema",
-      "version": "6.0.1",
+      "version": "7.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "exports": "./dist/index.js",
   "scripts": {
-    "generate": "node dist/cli.js"
+    "generate": "node dist/cli.js",
+    "serve": "node dist/serve.js"
   },
   "files": [
     "dist/index.*",

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -1,9 +1,5 @@
-import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { generate } from './cli.js';
 import http from 'http';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const HOSTNAME = '0.0.0.0';
 const PORT = 3001;

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -1,17 +1,7 @@
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import * as process from 'node:process';
-import * as fs from 'node:fs';
-import { Source, GraphQLError } from 'graphql';
-import { readSchemaSources } from './reader.js';
 import { generate } from './cli.js';
 import http from 'http';
-import {
-  SchemaFile,
-  SchemaLine,
-  SchemaMetadata,
-  SCHEMA_VERSION,
-} from './types.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -1,0 +1,58 @@
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as process from 'node:process';
+import * as fs from 'node:fs';
+import { Source, GraphQLError } from 'graphql';
+import { readSchemaSources } from './reader.js';
+import { generate } from './cli.js';
+import http from 'http';
+import {
+  SchemaFile,
+  SchemaLine,
+  SchemaMetadata,
+  SCHEMA_VERSION,
+} from './types.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const HOSTNAME = '0.0.0.0';
+const PORT = 3001;
+
+const server = http.createServer((req, res) => {
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'application/json');
+  res.setHeader('Access-Control-Allow-Origin', '*');
+
+  let output;
+  try {
+    output = generate();
+  } catch (e: any) {
+    res.statusCode = 500;
+    res.end(JSON.stringify({ error: e.message }));
+    return;
+  }
+
+  if (req.url === '/') {
+    const links = Object.keys(output).map(
+      (key) => `<a href="/${key}">${key}</a>`,
+    );
+    res.setHeader('Content-Type', 'text/html');
+    res.end(`<html><body>${links.join('<br>')}</body></html>`);
+    return;
+  }
+
+  const keys = Object.keys(output) as (keyof typeof output)[];
+  for (const key in keys) {
+    if (req.url === '/' + keys[key]) {
+      res.end(output[keys[key]]);
+      return;
+    }
+  }
+
+  res.statusCode = 404;
+  res.end(JSON.stringify({ error: 'Not found' }));
+});
+
+server.listen(PORT, HOSTNAME, () => {
+  console.log(`Server running at http://${HOSTNAME}:${PORT}/`);
+});


### PR DESCRIPTION
- Add an http server to live-serve local changes (this is planned to go
  with some poe-dat-viewer changes to make the schema URL configurable
  for live local testing)
- Add Dockerfiles for ease of running on systems without node (tested in
  podman)
- Add utility scripts to ease building/running
- `generate` entrypoint should behave exactly as it did previously by
  default, the output dir stuff is only due to volume mounts being
  required to have somewhere to output to while in docker
- Fix up the Gemtypes enum

Note that I have no idea what I'm doing with typescript, so I'm not
super able to judge whether the LLMs did a working job or a good job.
