### PR TITLE
Game mode

### DIFF
--- a/dat-schema/3_02_Bestiary.gql
+++ b/dat-schema/3_02_Bestiary.gql
@@ -93,7 +93,7 @@ type BestiaryRecipes @tags(list: ["item:recipe", "crafting"]) {
   _: bool
   _: i32
   _: i32
-  "1: Normal, 2: Ruthless"
+  "0: All, 1: Normal, 2: Ruthless"
   GameMode: i32
   FlaskMod: Mods
 }

--- a/dat-schema/_Core.gql
+++ b/dat-schema/_Core.gql
@@ -3155,8 +3155,8 @@ type Mods @tags(list: ["crafting"]) {
   ArchnemesisMinionMod: Mods
   HASH32: i32
   _: [rid]
-  # This is some enum and mods with value 2 looks to be disabled
-  Disabled2: i32
+  "0: All, 1: Normal, 2: Ruthless"
+  GameMode: i32
   _: [GrantedEffectsPerLevel]
 }
 


### PR DESCRIPTION
Column in Mods appears to represent which game modes the mod can spawn in. There is a similar column in BestiaryRecipes.

0 = All game modes
1 = Normal mode only
2 = Ruthless mode only