### PR TITLE
rename CopiedStats->IgnoredStats to accurately reflect their meaning

### DIFF
--- a/dat-schema/poe2/GrantedEffectStatSets.gql
+++ b/dat-schema/poe2/GrantedEffectStatSets.gql
@@ -7,7 +7,7 @@ type GrantedEffectStatSets {
   BaseEffectiveness: f32
   IncrementalEffectiveness: f32
   DamageIncrementalEffectiveness: f32
-  "Values for these stats are copied from the base StatSet of the GrantedEffect"
-  CopiedStats: [Stats]
+  "Values for these stats are NOT copied from the base StatSet of the GrantedEffect"
+  IgnoredStats: [Stats]
   _: bool
 }


### PR DESCRIPTION
The stats listed in this property _prevent the default behavior_ of copying stats from the main stat set to secondary sets.