### PR TITLE
Update Soul Cores for 0.2.0e

### DIFF
--- a/dat-schema/poe2/SoulCores.gql
+++ b/dat-schema/poe2/SoulCores.gql
@@ -1,8 +1,10 @@
 type SoulCores {
   BaseItemType: BaseItemTypes
-  StatsWeapon: [Stats]
-  StatsValuesWeapon: [i32]
+  StatsMartialWeapon: [Stats]
+  StatsValuesMartialWeapon: [i32]
   StatsArmour: [Stats]
   StatsValuesArmour: [i32]
-  _: i32
+  Rank: i32
+  StatsCasterWeapon: [Stats]
+  StatsValuesCasterWeapon: [i32]
 }


### PR DESCRIPTION
```gql
type SoulCores {
  BaseItemType: BaseItemTypes
  StatsMartialWeapon: [Stats]
  StatsValuesMartialWeapon: [i32]
  StatsArmour: [Stats]
  StatsValuesArmour: [i32]
  Rank: i32
  StatsCasterWeapon: [Stats]
  StatsValuesCasterWeapon: [i32]
}
```

Not sure on the naming for these the weapons and rank, so they may need some adjustment.

`StatsMartialWeapon` used to be just `StatsWeapon`, but since the caster weapons go their own columns, I thought it maybe a good idea to specify which "weapon" so added Martial. On the fence on that if it was necessary. 

The other one is `Rank`, this column's purpose is just defining ordering for the runes `{Lesser: 0, normal: 15, Greater: 30}`. I don't think rank is a great name but I can't really think of another. Maybe `Level` since that is what is used for the similar Essences in poe1 tables, but that ones column increments by 1 instead of 15 so didn't think it was the exact same. 