### PR TITLE
[poe2] Extra Soul Core columns

### DIFF
--- a/dat-schema/poe2/SoulCores.gql
+++ b/dat-schema/poe2/SoulCores.gql
@@ -7,4 +7,6 @@ type SoulCores {
   Rank: i32
   StatsCasterWeapon: [Stats]
   StatsValuesCasterWeapon: [i32]
+  StatsAllEquipment: [Stats]
+  StatsValuesAllEquipment: [i32]
 }


### PR DESCRIPTION
Adds 2 columns to soul cores for stats that apply to all equipment