### PR TITLE
Add column for essences with multiple possible outcomes

### DIFF
--- a/dat-schema/poe2/EssenceMods.gql
+++ b/dat-schema/poe2/EssenceMods.gql
@@ -3,8 +3,8 @@ type EssenceMods {
   Essence: Essences
   TargetItemCategory: EssenceTargetItemCategories
   Mod1: Mods
-  Mod2: Mods
+  DisplayMod: Mods
   Text: string @localized
-  _: [rid]
+  OutcomeMods: [Mods]
   _: [i32]
 }


### PR DESCRIPTION
* Change `Mod2` -> `DisplayMod` to better reflect that the mod only appears on the tooltip for essences that can roll several mods.  
* Add `OutcomeMods` which is the pool of mods that the essence rolls from when used


<img width="1434" height="753" alt="image" src="https://github.com/user-attachments/assets/be383508-a02b-4e9e-b42d-4c4fc07d0223" />  
