### PR TITLE
Fix schema for many dat files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# Development tools
+.idea/
+.vs/
+.vscode/
+*.code-workspace
+
 dist/
 schema.min.json
 schema.jsonl

--- a/dat-schema/2_04_Essence.gql
+++ b/dat-schema/2_04_Essence.gql
@@ -1,16 +1,16 @@
 type Essences @tags(list: ["item:def", "crafting"]) {
   BaseItemTypesKey: BaseItemTypes @unique
-  _: rid
-  _: rid
-  _: rid
-  _: rid
-  _: rid
-  _: rid
-  _: rid
-  _: rid
-  _: rid
-  _: rid
-  _: rid
+  _: rid # All rows empty
+  _: rid # All rows empty
+  _: rid # All rows empty
+  _: rid # All rows empty
+  _: rid # All rows empty
+  _: rid # All rows empty
+  _: rid # All rows empty
+  _: rid # All rows empty
+  _: rid # All rows empty
+  _: rid # All rows empty
+  _: rid # All rows empty
   Display_Wand_ModsKey: Mods
   Display_Bow_ModsKey: Mods
   Display_Quiver_ModsKey: Mods

--- a/dat-schema/3_03_Incursion.gql
+++ b/dat-schema/3_03_Incursion.gql
@@ -21,11 +21,8 @@ type IncursionChestRewards @tags(list: ["item:droptable"]) {
   IncursionRoomsKey: IncursionRooms
   IncursionChestsKeys: [IncursionChests]
   ChestMarkerMetadata: string @files(ext: [".ot", ".otc"])
-  _: i32
-  _: i32
-  _: i32
-  _: i32
-  _: i32
+  HASH32: u32
+  RuthlessIncursionChestsKeys: [IncursionChests]
   _: i32
   _: i32
   _: i32

--- a/dat-schema/3_03_Incursion.gql
+++ b/dat-schema/3_03_Incursion.gql
@@ -60,7 +60,7 @@ type IncursionRooms @tags(list: ["item:itemized"]) {
   RoomUpgrade_IncursionRoomsKey: IncursionRooms
   Mods: [Mods]
   PresentARMFile: string @file(ext: ".arm")
-  HASH16: i32 @unique
+  HASH16: u32
   IncursionArchitectKey: IncursionArchitect
   PastARMFile: string @file(ext: ".arm")
   TSIFile: string @file(ext: ".tsi")

--- a/dat-schema/3_03_Incursion.gql
+++ b/dat-schema/3_03_Incursion.gql
@@ -49,7 +49,7 @@ type IncursionRoomBossFightEvents {
   _: string
   _: string
   _: string
-  DeliriumAchievement: AchievementItems
+  TurretMonster: MonsterVarieties
 }
 
 type IncursionRooms @tags(list: ["item:itemized"]) {

--- a/dat-schema/3_07_Legion.gql
+++ b/dat-schema/3_07_Legion.gql
@@ -91,10 +91,10 @@ type LegionMonsterVarieties {
   _: [i32]
   _: [i32]
   _: [i32]
-  _: [rid]
+  _: [i32]
   _: i32
   _: i32
-  _: [rid]
+  _: [i32]
   MonsterVarietiesKey2: MonsterVarieties
 }
 

--- a/dat-schema/3_17_Archnemesis.gql
+++ b/dat-schema/3_17_Archnemesis.gql
@@ -23,14 +23,14 @@ type ArchnemesisMods {
 }
 
 type ArchnemesisModVisuals {
-  Id: string
-  _: MiscAnimated
-  _: rid
-  _: rid
-  _: [BuffVisuals]
-  _: [MonsterVarieties]
-  _: [MiscAnimated]
-  _: [rid]
+  Id: string @unique
+  MiscAnimated: MiscAnimated
+  StampFamily: StampFamily
+  MiscEffectPack: MiscEffectPacks
+  BuffVisual: [BuffVisuals]
+  Monster: [MonsterVarieties]
+  MonsterMiscAnimated: [MiscAnimated]
+  MonsterEffectPack: [MiscEffectPacks]
 }
 
 type ArchnemesisRecipes {

--- a/dat-schema/3_17_Siege_of_the_Atlas.gql
+++ b/dat-schema/3_17_Siege_of_the_Atlas.gql
@@ -73,7 +73,7 @@ type AtlasUpgradesInventoryLayout {
   _: i32
   Objective: string
   GrantAtlasUpgrade: QuestFlags
-  _: rid
+  SoundEffect: SoundEffects
 }
 
 type AtlasPassiveSkillTreeGroupType {

--- a/dat-schema/3_20_Sanctum.gql
+++ b/dat-schema/3_20_Sanctum.gql
@@ -78,8 +78,8 @@ type SanctumPersistentEffects {
   _: i32
   _: i32
   _: bool
-  _: [rid]
-  Guard: [MonsterVarieties]
+  ConditionalAchievement: [ConditionalAchievements]
+  Achievements: [AchievementItems]
   FirstEffect: SanctumPersistentEffects
   _: i32
   _: i32

--- a/dat-schema/3_21_Crucible.gql
+++ b/dat-schema/3_21_Crucible.gql
@@ -29,7 +29,7 @@ type WeaponPassiveSkills {
 }
 
 type CrucibleDifficulty {
-  Number: string @unique
+  Number: string
   Name: string @unique
   _: i32
   _: i32

--- a/dat-schema/3_22_Trial_of_the_Ancestors.gql
+++ b/dat-schema/3_22_Trial_of_the_Ancestors.gql
@@ -105,9 +105,9 @@ type AncestralTrialTribes {
   NPCHub: NPCs
   Portrait: string
   TribeIcon: string
-  TribeName: string @unique
+  TribeName: string
   FavourTracker: string
-  _: [rid]
+  UnlockQuestFlag: [QuestFlags]
   Name: string
   QuestFlagLike: QuestFlags
   QuestFlagDislike: QuestFlags

--- a/dat-schema/3_25_Settlers_of_Kalguur.gql
+++ b/dat-schema/3_25_Settlers_of_Kalguur.gql
@@ -180,13 +180,13 @@ type VillageUpgradeCategories {
 }
 
 type VillageUpgrades {
-  _: rid
+  Category: VillageUpgradeCategories
   Tier: i32
   Text: string
   _: i32
-  _: [rid]
-  _: [i32]
-  _: i32
+  UpgradeResource: [VillageResources]
+  UpgradeResourceCount: [i32]
+  GoldCost: i32
   RuneItem: [BaseItemTypes]
   _: [i32]
   Stats: [Stats]

--- a/dat-schema/3_25_Settlers_of_Kalguur.gql
+++ b/dat-schema/3_25_Settlers_of_Kalguur.gql
@@ -39,7 +39,7 @@ type VillageBalancePerLevelShared {
   MaxAccountLevel: i32
   _: i32
   _: i32
-  _: i32
+  GoldRespecCost: i32
   _: i32
   _: i32
   _: i32

--- a/dat-schema/3_26_Mercenaries.gql
+++ b/dat-schema/3_26_Mercenaries.gql
@@ -2,13 +2,13 @@ type MercenaryClasses {
   Id: string
   MonsterVariety: MonsterVarieties
   _: i32
-  Build: MercenaryBuilds
+  TerrainFeature: ExtraTerrainFeatures
   _: i32
   _: i32
-  Icon: string
-  House: string
-  _: MercenaryClasses
-  _: [_] # All rows empty
+  ClassIcon: string
+  HouseIcon: string
+  Attribute: MercenaryAttributes
+  HouseBuffIcon: string
   MonsterVarietyAllied: MonsterVarieties
 }
 
@@ -57,10 +57,10 @@ type MercenaryFlavourText {
 }
 
 type MercenaryInventories {
-  Id: MercenaryClasses
+  Id: Inventories
   _: i32
-  _: i32
-  _: i32
+  PositionX: i32
+  PositionY: i32
   _: i32
 }
 

--- a/dat-schema/3_27_Keepers_of_the_Flame.gql
+++ b/dat-schema/3_27_Keepers_of_the_Flame.gql
@@ -5,7 +5,7 @@ type BreachBossLifeScalingPerLevel {
 
 type BreachElement {
   Element: string @unique
-  _: rid
+  ShardBaseItemType: BaseItemTypes
   BaseBreachstone: BaseItemTypes
   BossMapMod: Stats
   DuplicateBoss: Stats
@@ -65,6 +65,22 @@ type BrequelGrafts {
   SkillGem: SkillGems
   _: i32
   SkillAnimation: string
+}
+
+type BrequelGraftInventoryLayout {
+  Inventory: Inventories
+  QuestFlag: QuestFlags
+  _: i32
+}
+
+type BrequelGraftTypes {
+  BaseItemType: BaseItemTypes @unique
+  AOFileLeftArm: string @file(ext: ".ao")
+  AOFileRightArm: string @file(ext: ".ao")
+  NPC: NPCs
+  _: i32
+  AISFile: string @file(ext: ".ais")
+  Achievement: AchievementItems
 }
 
 type BrequelGraftSkillStats {

--- a/dat-schema/_Core.gql
+++ b/dat-schema/_Core.gql
@@ -1353,7 +1353,7 @@ type DamageParticleEffects {
 enum DamageParticleEffectTypes @indexing(first: 0) { _ }
 
 type Dances {
-  BaseItemTypesKey: BaseItemTypes
+  MtxTypeKey: MtxTypes
   CharactersKey: Characters
 }
 
@@ -1632,7 +1632,10 @@ type ExecuteGEAL {
   _: [_] # All rows empty
   _: bool
   _: i32
-  _: rid
+  _: i32
+  _: i32
+  _: i32
+  _: i32
   _: bool
   Script: string
   _: bool
@@ -2815,7 +2818,7 @@ type MapFragmentMods {
   _: i32
   MapFragmentLimit: i32
   _: bool
-  _: [rid]
+  _: [i32]
 }
 
 type MapInhabitants {
@@ -3068,8 +3071,8 @@ type MicrotransactionCharacterPortraitVariations {
 
 type MicrotransactionCombineFormula {
   Id: string
-  Result_BaseItemTypesKey: BaseItemTypes
-  Ingredients_BaseItemTypesKeys: [BaseItemTypes]
+  Result_Mtx: MtxTypeGameSpecific
+  Ingredients_Mtx: [MtxTypeGameSpecific]
   BK2File: string @file(ext: ".bk2")
   _: [i32]
   _: i32
@@ -4013,7 +4016,7 @@ type MusicCategories {
 }
 
 type MysteryBoxes {
-  BaseItemTypesKey: BaseItemTypes
+  MtxTypesKey: MtxTypes
   BK2File: string @file(ext: ".bk2")
   BoxId: string
   BundleId: string
@@ -4908,7 +4911,7 @@ type RunicCircles {
 }
 
 type SalvageBoxes {
-  BaseItemType: BaseItemTypes
+  MtxType: MtxTypeGameSpecific
   Id: string @unique
   _: string
 }
@@ -5322,7 +5325,7 @@ type TableCharge {
   _: f32
   _: f32
   _: bool
-  MiscAnimatedArtVariations: MiscAnimatedArtVariations
+  _: rid
   _: bool
   TravelAnimation: [MiscAnimated]
   ImpactAnimation: MiscAnimated
@@ -5390,7 +5393,7 @@ type TableMonsterSpawners {
 
 type Tags {
   Id: string @unique
-  _: i32
+  HASH32: u32
   DisplayString: string
   Name: string
 }
@@ -5876,14 +5879,14 @@ type ActionTypes {
 
 # Added 3.21
 type ActiveSettings {
-  _: string @unique
+  Id: string @unique
   _: i32
   _: i32
-  _: rid
-  _: rid
-  _: rid
-  _: rid
   _: i32
+  LeagueInfoPanel: LeagueInfoPanelVersions
+  NewLeaguePopup: TryTheNewLeagueVersions
+  Logo: GameLogos
+  BackendError: BackendErrors
 }
 
 # Added 3.23
@@ -5940,7 +5943,7 @@ type BattlePassRewards {
   _: i32
   _: bool
   Id: string
-  RewardedMTX: [BaseItemTypes]
+  RewardedMTX: [MtxTypeGameSpecific]
   _: i32
   RewardDescription: string
   _: string
@@ -6281,8 +6284,8 @@ type HardModeExtraContentChances {
 
 # Added 3.22
 type HardModeExtraContentChancesPerMapTier {
-  _: rid @unique
-  _: i32
+  Tier: i32
+  ContentChance: HardModeExtraContentChances @unique
 }
 
 # Added 3.19
@@ -6378,8 +6381,8 @@ type HudVisualsFromStat {
 
 # Added 3.23
 type InfluenceAmbushVariations {
-  _: rid
-  _: i32
+  Id: i32
+  Stat: Stats
   _: f32
   Monsters: [MonsterVarieties]
   _: i32
@@ -6553,8 +6556,8 @@ type MicrotransactionChargeVariations {
 
 # Added 3.19
 type MicrotransactionConditionalApparitionEvents {
-  _: rid
-  _: i32
+  EventId: i32
+  Apparition: MicrotransactionConditionalApparitions @unique
   _: f32
   _: NPCTextAudio
   _: bool
@@ -6572,10 +6575,13 @@ type MicrotransactionConditionalApparitions {
   Stats: [Stats]
   StatValues: [i32]
   PeriodicVariation: MicrotransactionPeriodicCharacterEffectVariations
-  _: rid
+  _: i32
+  _: i32
+  _: i32
+  _: i32
+  _: i32
   _: i32
   _: bool
-  _: i32
   _: bool
 }
 
@@ -6872,7 +6878,7 @@ type SummonedSpecificMonstersOnDeathStats {
 
 # Added 3.19
 type TieredMicrotransactions {
-  MTX: BaseItemTypes @unique
+  MTX: MtxTypeGameSpecific @unique
   TierThresholds: [i32]
   _: Stats
   _: [i32]
@@ -6889,7 +6895,7 @@ type TieredMicrotransactions {
 
 # Added 3.22
 type TieredMicrotransactionsVisuals {
-  MTX: BaseItemTypes
+  MTX: MtxTypes
   Tier: i32
   Description: string
   DDSFile: string @file(ext: ".dds")

--- a/dat-schema/_Core.gql
+++ b/dat-schema/_Core.gql
@@ -11,7 +11,7 @@ type AtlasTrees {
 
 type AchievementItemRewards @tags(list: ["mtx:reward"]) {
   AchievementItemsKey: AchievementItems
-  BaseItemTypesKey: BaseItemTypes
+  Rewards: MtxTypeGameSpecific
   Message: string
   Id: string
 }
@@ -362,18 +362,18 @@ type AreaTransitionAnimationTypes {
 type AreaTransitionInfo {
   StartingArea: WorldAreas
   EndingArea: WorldAreas
-  _: rid
-  _: rid
-  _: rid
-  _: rid
-  _: rid
-  _: rid
-  _: rid
-  _: rid
+  AnimationType: AreaTransitionAnimationTypes
+  AnimationMarauder: AreaTransitionAnimations
+  AnimationRanger: AreaTransitionAnimations
+  AnimationWitch: AreaTransitionAnimations
+  AnimationDualist: AreaTransitionAnimations
+  AnimationTemplar: AreaTransitionAnimations
+  AnimationShadow: AreaTransitionAnimations
+  AnimationScion: AreaTransitionAnimations
   Animation: MiscAnimated
-  MiscObject: [MiscObjects]
+  MiscObjectGround: [MiscObjects]
   _: i32
-  _: [rid]
+  BossObject: [MiscObjects]
 }
 
 enum AreaType @indexing(first: 0) { _ }
@@ -418,6 +418,12 @@ type Ascendancy {
   _: i32
   _: i32
   LeagueIcon: string
+}
+
+type AtlasFavouredMapSlots {
+  SlotId: i32
+  _: i32
+  Unlock: string
 }
 
 type AtlasMissionTypes {
@@ -946,7 +952,7 @@ type Characters {
   _: SkillGems
   StartingWeaponBase: BaseItemTypes
   _: i32
-  _: [rid]
+  Mods: [Mods]
   PassiveTreeImage: string @file(ext: ".dds")
   _: i32
   _: i32
@@ -1002,7 +1008,7 @@ type CharacterStartStates {
   CharacterStartQuestStateKeys: [CharacterStartQuestState]
   _: bool
   InfoText: string
-  _: rid
+  Ascendancy: Ascendancy
 }
 
 type CharacterStartStateSet {
@@ -1257,7 +1263,7 @@ type CraftingBenchSortCategories {
 
 type CraftingBenchTypes {
   Id: string
-  _: rid
+  HideoutDoodad: HideoutCraftingBenchDoodads
   _: bool
 }
 
@@ -1335,7 +1341,7 @@ type DamageHitEffects {
   Id: i32
   _: i32
   _: i32
-  DamageEffectPC: [DamageEffectVariations]
+  DamageEffectPC: [DamageEffectVariations] @unique
   DamageEffectConsole: [DamageEffectVariations]
 }
 
@@ -1375,19 +1381,19 @@ type DefaultMonsterStats {
   Damage: f32
   Evasion: i32
   Accuracy: i32
-  Life: i32
+  MonsterLife: i32
   Experience: i32
-  AllyLife: i32
-  _: i32
-  Difficulty: i32
-  Damage2: f32
-  _: i32
-  _: f32
-  _: f32
-  _: i32
-  _: i32
+  MinionLife: i32
   Armour: i32
-  _: i32
+  Difficulty: i32
+  MinionDamage: f32
+  AltLife1: i32
+  AltDamage1: f32
+  AltDamage2: f32
+  AltLife2: i32
+  EvasiveEvasion: i32
+  AilmentThreshold: i32
+  MonsterPhysConversionMulti: i32
 }
 
 type DeliriumStashTabLayout {
@@ -1591,7 +1597,7 @@ type EnvironmentTransitions {
   OTFiles: [string] @file(ext: ".ot")
   _: i32
   Environment: [Environments]
-  _: [_] # All rows empty
+  _: [string]
   _: i32
 }
 
@@ -2005,7 +2011,7 @@ type GeometryTrigger {
   _: i32
   _: bool
   _: bool
-  _: rid
+  MiscAnimated: MiscAnimated
   _: bool
   _: bool
   _: i32
@@ -2233,7 +2239,7 @@ type HideoutNPCs {
   Regular_NPCsKeys: [NPCs]
   HideoutDoodadsKey: HideoutDoodads
   NPCMasterKey: i32
-  _: rid
+  _: rid # All rows empty
   QuestFlag: QuestFlags
   _: i32
   Quest: Quest
@@ -2450,10 +2456,10 @@ type ItemisedVisualEffect {
   Name: [Words]
   _: bool
   _: [_] # All rows empty
-  _: [rid]
+  Character: [Characters]
   GrantedEffect: [GrantedEffectsPerLevel]
   OnKillEffect: [MicrotransactionOnKillEffects]
-  _: rid
+  _: rid # All rows empty
   _: bool
   EffectSlotType: MicrotransactionSkillGemEffectSlotTypes
   VisualEffectType: ItemisedVisualEffectExclusiveTypes
@@ -2521,6 +2527,19 @@ type ItemVisualHeldBodyModel {
   ScionBone: string
 }
 
+# Removed 3.26.0j
+type ItemVisualHeldBodyModelOverrideByItemAffiliatedAttributes {
+  VisualIdentity: ItemVisualIdentity
+  _: string @file(ext: ".ao")
+  _: string @file(ext: ".ao")
+  _: string @file(ext: ".ao")
+  _: string @file(ext: ".ao")
+  _: string @file(ext: ".ao")
+  _: string @file(ext: ".ao")
+  _: string @file(ext: ".ao")
+}
+
+# Added 3.26.0j
 type ItemVisualHeldModelOverrideByItemAffiliatedAttributes {
   VisualIdentity: ItemVisualIdentity
   ItemClass: ItemClasses
@@ -2757,7 +2776,7 @@ type MapDeviceRecipes @tags(list: ["item:recipe"]) {
   _: i32
   Mods: [Mods]
   _: bool
-  _: [_] # All rows empty
+  _: [i32]
   AtlasNode: AtlasNode
 }
 
@@ -2788,15 +2807,9 @@ type MapDevices {
   _: i32
   _: bool
   _: i32
-  _: bool
-  _: f32
   _: i32
   _: i32
-  _: i32
-  _: i32
-  _: bool
-  _: bool
-  _: bool
+  _: [i32]
 }
 
 enum MapFragmentFamilies @indexing(first: 0) { _ }
@@ -2964,9 +2977,9 @@ type MapStashSpecialTypeEntries {
   _: i32
   IsShaperGuardian: bool
   IsElderGuardian: bool
-  _: rid
-  _: rid
-  _: rid
+  ElderGuardian: ElderGuardians
+  Conqueror: AtlasExiles
+  ItemVisualIdentity: ItemVisualIdentity
 }
 
 type MapStashSpecialSubStashGroup {
@@ -3053,7 +3066,7 @@ type MetamorphosisStashTabLayout {
 type MicroMigrationData {
   Mtx: MtxTypeGameSpecific
   _: i32
-  _: rid
+  MysteryBox: MysteryBoxes
   MtxPack: MtxTypeGameSpecific
 }
 
@@ -3514,7 +3527,7 @@ type MonsterConditions {
   MapBoss: bool
   NotMapBoss: bool
   Tags: [Tags]
-  _: [string]
+  NotTags: [Tags]
   _: i32
   _: i32
   _: i32
@@ -3528,7 +3541,7 @@ type MonsterDeathAchievements {
   _: bool
   PlayerConditionsKeys: [PlayerConditions]
   MonsterDeathConditionsKeys: [MonsterDeathConditions]
-  _: [rid]
+  Area: [WorldAreas]
   _: i32
   _: i32
   _: bool
@@ -3544,7 +3557,7 @@ type MonsterDeathAchievements {
   MultiPartAchievementConditionsKeys: [MultiPartAchievementConditions]
   _: [i32]
   _: bool
-  Area: [WorldAreas]
+  LeagueArea: [WorldAreas]
   Stat: [Stats]
   _: bool
 }
@@ -4137,7 +4150,7 @@ type NPCMaster {
   Signature_ModsKey: Mods
   SpawnWeight_TagsKeys: [Tags]
   SpawnWeight_Values: [i32]
-  _: rid # All rows empty
+  Stat: Stats
   Achievement: [AchievementItems]
   AfflictionAchievement: [AchievementItems]
   League: CoreLeagues
@@ -4338,7 +4351,7 @@ type PassiveSkillFilterCatagories {
 
 type PassiveSkillFilterOptions {
   Id: string @unique
-  _: rid
+  FilterCatagory: PassiveSkillFilterCatagories
   Name: string
   _: string
 }
@@ -5295,7 +5308,7 @@ type SummonedSpecificMonsters {
   _: i32
   _: i32
   _: bool
-  _: rid
+  ModFamily: ModFamily
   _: rid # All rows empty
   _: i32
   _: bool
@@ -5484,19 +5497,22 @@ type TradeMarketCategory {
   IsDisabled: bool
 }
 
+# Removed 3.27
 type TradeMarketCategoryGroups {
   Id: string
   Name: string @localized
 }
 
+# Removed 3.27
 type TradeMarketCategoryListAllClass {
   TradeCategory: TradeMarketCategory
   ItemClass: ItemClasses
 }
 
+# Removed 3.27
 type TradeMarketIndexItemAs {
-  Item: rid
-  IndexAs: rid
+  Item: BaseItemTypes
+  IndexAs: BaseItemTypes
 }
 
 enum TradeMarketCategoryStyleFlag @indexing(first: 0) { _ }
@@ -5793,7 +5809,8 @@ type WorldAreas {
   TerrainPlugin: TerrainPlugins
   _: bool
   _: bool
-  _: WorldAreas
+  _: i32
+  _: i32
   _: i32
   _: [i32]
   LeagueChance1: WorldAreaLeagueChances
@@ -5885,7 +5902,9 @@ type AbyssBossLifeScalingPerLevel {
 # Added 3.23
 type ActionTypes {
   Id: string @unique
-  _: i32
+  HASH16: u16
+  _: bool
+  _: bool
 }
 
 # Added 3.21
@@ -5962,19 +5981,13 @@ type BattlePassRewards {
   _: i32
   _: bool
   RewardTitle: string
-  _: rid
-  _: bool
+  ItemFrameType: ItemFrameType
   _: i32
   _: i32
   _: i32
   _: i32
+  BaseItemTypeReward: BaseItemTypes
   _: i32
-  _: i32
-  _: i32
-  _: i32
-  _: bool
-  _: bool
-  _: bool
 }
 
 # Added 3.21
@@ -6008,7 +6021,7 @@ type BreachLifeScalingPerLevel {
 type Breachstones {
   BaseType: BaseItemTypes @unique
   MapTierEquivalent: i32
-  _: i32
+  HASH32: u32
   UpgradesTo: BaseItemTypes
   UpgradeCurrency: BaseItemTypes
 }
@@ -6129,8 +6142,8 @@ type DamageEffectVariations {
 
 # Added 3.20
 type DamageWhenHitEffects {
-  _: rid @unique
-  _: rid
+  Stat: Stats @unique
+  HitEffect: DamageHitEffects
   _: bool
 }
 
@@ -6196,8 +6209,8 @@ type FlaskStashBaseTypeOrdering {
 type GameObjectTasksFromStats {
   Stat: Stats @unique
   GameObjectTask: GameObjectTasks
-  _: bool
   _: i32
+  _: bool
   _: bool
   _: bool
   _: bool
@@ -6282,15 +6295,12 @@ type GoldPriceMultiFromTag {
 # Added 3.20
 type HardModeExtraContentChances {
   Id: string @unique
-  _: i32
-  _: i32
+  SingleSpawnChance: i32
+  DoubleSpawnChance: i32
+  TripleSpawnChance: i32
+  NoSpawnChance: i32
+  Leagues: [CoreLeagues]
   _: bool
-  _: i32
-  _: i32
-  _: i32
-  _: i32
-  _: i32
-  _: i32
 }
 
 # Added 3.22
@@ -6469,7 +6479,7 @@ type MapStashSubstashGroup {
   Id: string @unique
   Label: string
   Icon: string
-  _: rid
+  MapTier: MapTiers
   Description: string
 }
 
@@ -6921,9 +6931,10 @@ type TormentedSpiritLifeScalingPerLevel {
 }
 
 # Added 3.19
+# Removed 3.27
 type TradeMarketImplicitModDisplay {
-  _: rid @unique
-  _: string
+  Mod: Mods @unique
+  Text: string
 }
 
 type TradeWindowVisuals {

--- a/dat-schema/_Core.gql
+++ b/dat-schema/_Core.gql
@@ -168,8 +168,6 @@ type AdditionalLifeScaling {
   _: bool
 }
 
-enum AdditionalLifeScalingPerLevel @indexing(first: 0) { _ }
-
 type AdditionalMonsterPacksFromStats {
   StatsKey: Stats
   _: i32
@@ -626,7 +624,7 @@ type BaseItemTypes @tags(list: ["item:def", "item:droptable"]) {
   TagsKeys: [Tags]
   ModDomain: ModDomains
   ItemVisualIdentity: ItemVisualIdentity
-  HASH32: i32 @unique
+  HASH32: i32
   VendorRecipe_AchievementItems: [AchievementItems]
   "the inflection identifier used for i18n in related fields"
   Inflection: string
@@ -917,7 +915,7 @@ type CharacterPanelTabs {
 
 type Characters {
   Id: string @unique
-  Name: string @unique @localized
+  Name: string @localized
   AOFile: string @file(ext: ".ao")
   ACTFile: string @file(ext: ".act")
   BaseMaxLife: i32
@@ -928,7 +926,7 @@ type Characters {
   MaxDamage: i32
   MaxAttackDistance: i32
   Icon: string
-  IntegerId: i32 @unique
+  IntegerId: i32
   BaseStrength: i32
   BaseDexterity: i32
   BaseIntelligence: i32
@@ -1397,7 +1395,7 @@ type DeliriumStashTabLayout {
   StoredItem: BaseItemTypes
   XOffset: i32
   YOffset: i32
-  FirstSlotIndex: i32 @unique
+  FirstSlotIndex: i32
   Width: i32
   Height: i32
   SlotSize: i32
@@ -1409,7 +1407,7 @@ type DelveStashTabLayout {
   StoredItem: BaseItemTypes
   XOffset: i32
   YOffset: i32
-  FirstSlotIndex: i32 @unique
+  FirstSlotIndex: i32
   Width: i32
   Height: i32
   SlotSize: i32
@@ -1602,7 +1600,7 @@ type EssenceStashTabLayout {
   StoredItem: BaseItemTypes
   XOffset: i32
   YOffset: i32
-  FirstSlotIndex: i32 @unique
+  FirstSlotIndex: i32
   Width: i32
   Height: i32
   IsUpgradableEssenceSlot: bool
@@ -1840,7 +1838,7 @@ type GamepadType {
 
 type GameStats {
   Id: string @unique
-  Id2: string @unique
+  Id2: string
 }
 
 type GemTags {
@@ -2489,7 +2487,7 @@ type ItemVisualEffect {
   _: string
   TwoHandedSwordEPKFile: string @file(ext: ".epk")
   TwoHandedStaffEPKFile: string @file(ext: ".epk")
-  HASH16: i16 @unique
+  HASH16: u16
   TwoHandedMaceEPKFile: string @file(ext: ".epk")
   OneHandedAxeEPKFile: string @file(ext: ".epk")
   TwoHandedAxeEPKFile: string @file(ext: ".epk")
@@ -2540,7 +2538,7 @@ type ItemVisualIdentity {
   DDSFile: string @file(ext: ".dds")
   AOFile: string @file(ext: ".ao")
   InventorySoundEffect: SoundEffects
-  HASH16: i16 @unique
+  HASH16: u16
   AOFile2: string @file(ext: ".ao")
   MarauderSMFiles: [string] @file(ext: ".sm")
   RangerSMFiles: [string] @file(ext: ".sm")
@@ -2674,8 +2672,8 @@ type LeagueInfoPanelVersions {
 
 type LeagueNames {
   Id: string @unique
-  Name1: string @unique @localized
-  Name2: string @unique @localized
+  Name1: string @localized
+  Name2: string @localized
 }
 
 type LeagueProgressQuestFlags {
@@ -3257,8 +3255,6 @@ type MiscObjectsArtVariations {
   _: i32
   Stat: Stats
 }
-
-enum MissionTileMap @indexing(first: 0) { _ }
 
 type MissionTimerTypes {
   Id: string
@@ -4407,7 +4403,7 @@ type PassiveSkills {
   Stat3Value: i32
   Stat4Value: i32
   "Id used by PassiveSkillGraph.psg"
-  PassiveSkillGraphId: u16 @unique
+  PassiveSkillGraphId: u16
   Name: string
   Characters: [Characters]
   IsKeystone: bool
@@ -4992,6 +4988,11 @@ type SkillGemInfo {
   CharactersKeys: [Characters]
 }
 
+type SkillGemGoldPricePerQuality {
+    Quality: i32
+    Price: i32
+}
+
 type SkillGems @tags(list: ["item:def"]) {
   BaseItemTypesKey: BaseItemTypes @unique
   StrengthRequirementPercent: i32
@@ -5168,6 +5169,16 @@ type StashTabAffinities {
   _: i32
 }
 
+type StashTabAffinityByBaseItemType {
+  BaseItemType: BaseItemTypes @unique
+  StashTabAffinityId: [StashTabAffinityId]
+}
+
+type StashtabAffinityByItemClassCategory {
+  ItemClassCategory: ItemClassCategories @unique
+  StashTabAffinityId: StashTabAffinityId
+}
+
 type StashTabAffinityId {
   Id: string @unique
 }
@@ -5180,7 +5191,7 @@ type StashAvailabilities {
 
 type StashType {
   Id: string @unique
-  StashId: StashId @unique
+  StashId: StashId
   Id2: string
   StorageSlots: i32
   _: i32
@@ -5197,7 +5208,7 @@ type StaticLifeBarStyle {
 }
 
 type StatDescriptionFunctions {
-  Id: string @unique
+  Id: string
   TranslationId: string @unique
 }
 
@@ -5434,7 +5445,7 @@ type TencentAutoLootPetCurrenciesExcludable {
 
 type TerrainPlugins {
   Id: string @unique
-  _: i32 @unique
+  _: i32
   _: bool
   _: bool
 }
@@ -5997,7 +6008,7 @@ type BreachLifeScalingPerLevel {
 type Breachstones {
   BaseType: BaseItemTypes @unique
   MapTierEquivalent: i32
-  _: i32 @unique
+  _: i32
   UpgradesTo: BaseItemTypes
   UpgradeCurrency: BaseItemTypes
 }
@@ -6178,7 +6189,7 @@ type EntityInfobarStyle {
 # Added 3.17
 type FlaskStashBaseTypeOrdering {
   Flask: Flasks @unique
-  Order: i32 @unique
+  Order: i32
 }
 
 # Added 3.20
@@ -6203,7 +6214,7 @@ type GamepadButtonCombination {
 # Added 3.17
 type GamepadThumbstick {
   _: string @unique
-  _: string @unique
+  _: string
 }
 
 # Added 3.23

--- a/dat-schema/_Core.gql
+++ b/dat-schema/_Core.gql
@@ -837,8 +837,8 @@ type BuffVisuals {
   MiscAnimated3: MiscAnimated
   WeaponEffect: SkillWeaponEffects
   _: string
-  _: i32
-  _: i32
+  _: f32
+  _: f32
   _: bool
   _: bool
   _: [string]
@@ -2289,7 +2289,7 @@ type IndexableSkillGems {
   Name1: string
   SkillGem2: [SkillGems]
   Name2: string
-  _: IndexableSkillGems
+  IndexRuthless: IndexableSkillGems
 }
 
 type IndexableSupportGems @tags(list: ["crafting"]) {
@@ -3421,10 +3421,10 @@ type Mods @tags(list: ["crafting"]) {
   SpawnWeight_Values: [i32]
   TagsKeys: [Tags]
   GrantedEffectsPerLevelKeys: [GrantedEffectsPerLevel]
-  _: [i32]
+  _: [rid]
   MonsterMetadata: string
   MonsterKillAchievements: [AchievementItems]
-  ChestModType: [ModType]
+  ArchnemesisType: [ModType]
   Stat5Min: i32
   Stat5Max: i32
   StatsKey5: Stats
@@ -3442,7 +3442,7 @@ type Mods @tags(list: ["crafting"]) {
   CraftingItemClassRestrictions: [ItemClasses]
   MonsterOnDeath: string
   _: i32
-  _: [GrantedEffectsPerLevel]
+  HeistAchievements: [AchievementItems]
   Heist_SubStatValue1: i32
   Heist_SubStatValue2: i32
   Heist_StatsKey0: Stats
@@ -3529,8 +3529,8 @@ type MonsterConditions {
   Tags: [Tags]
   NotTags: [Tags]
   _: i32
-  _: i32
-  _: i32
+  MinimumLevel: i32
+  MaximumLevel: i32
   HASH32: u32
 }
 
@@ -3800,16 +3800,16 @@ type MonsterSpawnerOverrides {
 
 type MonsterTypes {
   Id: string @unique
-  _: i32
-  _: i32
-  IsSummoned: bool
+  Accuracy: i32
+  IsPlayerMinion: bool
   Armour: i32
   Evasion: i32
+  EnergyShield: i32
   DamageSpread: i32
-  MonsterResistancesKey: MonsterResistances
-  IsLargeAbyssMonster: bool
-  IsSmallAbyssMonster: bool
-  _: bool
+  Resistances: MonsterResistances
+  AltLife1: bool
+  AltLife2: bool
+  BaseDamageIgnoresAttackSpeed: bool
 }
 
 type MonsterVarieties {
@@ -3837,11 +3837,11 @@ type MonsterVarieties {
   "in percent"
   ExperienceMultiplier: i32
   _: [i32]
-  _: i32
-  _: i32
-  _: i32
-  CriticalStrikeChance: i32
-  _: i32
+  MinAgroRange: i32
+  MaxAgroRange: i32
+  SpotlightColour1: i32
+  SpotlightColour2: i32
+  SpotlightColour3: i32
   GrantedEffectsKeys: [GrantedEffects]
   AISFile: string @file(ext: ".ais")
   ModsKeys2: [Mods]
@@ -3871,7 +3871,7 @@ type MonsterVarieties {
   _: i32
   _: i32
   _: i32
-  HASH16: i16
+  HASH16: u16
   _: bool
   _: string
   KillWhileOnslaughtIsActive_AchievementItemsKey: AchievementItems
@@ -3896,7 +3896,7 @@ type MonsterVarieties {
   _: i32
   _: i32
   _: f32
-  _: i32
+  AilmentThreshold: i32
   EPKFile: string
   _: i32
   MonsterConditionalEffectPacksKey: MonsterConditionalEffectPacks
@@ -4674,7 +4674,7 @@ type Projectiles {
   _: [string]
   _: bool
   _: [i32]
-  _: Projectiles
+  _: string
 }
 
 type ProjectilesArtVariations {
@@ -4682,7 +4682,7 @@ type ProjectilesArtVariations {
   Variant: i32
   Projectiles: [Projectiles]
   _: i32
-  _: rid # All rows empty
+  Stat: Stats
 }
 
 type PVPTypes {
@@ -5022,10 +5022,10 @@ type SkillGems @tags(list: ["item:def"]) {
   _: bool
   AwakenedVariant: SkillGems
   RegularVariant: SkillGems
-  _: i32
+  GemColour: i32
   ItemExperienceType: ItemExperienceTypes
   MtxSlotTypes: [MicrotransactionSkillGemEffectSlotTypes]
-  GemEffects: [GemEffects]
+  GemVariants: [GemEffects]
 }
 
 enum SkillMines @indexing(first: 0) { _ }

--- a/dat-schema/poe2/SkillGemGoldPricePerQuality.gql
+++ b/dat-schema/poe2/SkillGemGoldPricePerQuality.gql
@@ -1,4 +1,0 @@
-type SkillGemGoldPricePerQuality {
-    Quality: i32
-    Price: i32
-}

--- a/dat-schema/poe2/StashTabAffinityByBaseItemType.gql
+++ b/dat-schema/poe2/StashTabAffinityByBaseItemType.gql
@@ -1,5 +1,0 @@
-# Added 4.3
-type StashTabAffinityByBaseItemType {
-  BaseItemType: BaseItemTypes @unique
-  StashTabAffinityId: [StashTabAffinityId]
-}

--- a/dat-schema/poe2/StashtabAffinityByItemClassCategory.gql
+++ b/dat-schema/poe2/StashtabAffinityByItemClassCategory.gql
@@ -1,5 +1,0 @@
-# Added 4.3
-type StashtabAffinityByItemClassCategory {
-  ItemClassCategory: ItemClassCategories @unique
-  StashTabAffinityId: StashTabAffinityId
-}


### PR DESCRIPTION
Fixes the many microtransaction dats that previously referred to BaseItemTypes
Fixes tables that had the wrong structure
Fix more dats with unknown rids
Remove duplicate @unique entries for the same table
Specify unknown rid columns if they have all empty values
Remove PoE 2 schema for some tables as it now mirors PoE 1
Fix many old dat files by using older local game files
Fix some tables based on PoB schema

Add gitignore for .idea files used by PyCharm