### PR TITLE
Add RegularVariant self-referencing row matching poe 1 structure

### DIFF
--- a/dat-schema/poe2/_Core.gql
+++ b/dat-schema/poe2/_Core.gql
@@ -5322,7 +5322,8 @@ type SkillGems @tags(list: ["item:def"]) {
   GemType: i32
   _: bool
   _: bool
-  Awakened: SkillGems
+  AwakenedVariant: SkillGems
+  RegularVariant: SkillGems
   GemColour: i32
   MinLevelReq: i32
   ItemExperienceType: ItemExperienceTypes


### PR DESCRIPTION
Recent update changed from foreignrow (16 bytes) to row (8 bytes) causing length problems. But matching the poe 1 structure with both awakened and regular variants fit.