### PR TITLE
More 0.5 fixes

### DIFF
--- a/dat-schema/poe2/_Core.gql
+++ b/dat-schema/poe2/_Core.gql
@@ -2453,7 +2453,7 @@ type ExpeditionRelics {
   Id: string @unique
   Name: string
   ItemTag: Tags
-  AOFile: string
+  AOFiles: [string]
   MinLevel: i32
   MaxLevel: i32
   WorldArea: WorldAreas
@@ -6419,6 +6419,9 @@ type Strongboxes {
   _: bool
   SpawnWeightIncrease: Stats
   SpawnWeightHardmode: i32
+  BasicSpawnChanceStat: Stats
+  RequiredSpawnStat: [Stats]
+  BlockingSpawnStat: [Stats]
 }
 
 type StrongboxPacks {


### PR DESCRIPTION
Missed these 2 fixes and not sure if we want to add a new datatype for the colour bytes in EndGameMapContentVisualIdentity
<img width="87" height="212" alt="image" src="https://github.com/user-attachments/assets/0203b3a8-897e-49c8-91d7-9896c04ac1ac" />
