### PR TITLE
Rename 'heist' stats to stat7 and stat8

### DIFF
--- a/dat-schema/_Core.gql
+++ b/dat-schema/_Core.gql
@@ -3457,12 +3457,12 @@ type Mods @tags(list: ["crafting"]) {
   MonsterOnDeath: string
   _: i32
   HeistAchievements: [AchievementItems]
-  Heist_SubStatValue1: i32
-  Heist_SubStatValue2: i32
-  Heist_StatsKey0: Stats
-  Heist_StatsKey1: Stats
-  Heist_AddStatValue1: i32
-  Heist_AddStatValue2: i32
+  Stat7Min: i32
+  Stat7Max: i32
+  StatsKey7: Stats
+  StatsKey8: Stats
+  Stat8Min: i32
+  Stat8Max: i32
   InfluenceTypes: InfluenceTypes
   ImplicitTagsKeys: [Tags]
   _: bool

--- a/dat-schema/poe2/_Core.gql
+++ b/dat-schema/poe2/_Core.gql
@@ -4547,12 +4547,10 @@ type Mods @tags(list: ["crafting"]) {
   MonsterOnDeath: string
   _: i32
   HeistAchievements: [AchievementItems]
-  Heist_SubStatValue1: i32
-  Heist_SubStatValue2: i32
-  Heist_Stat0: Stats
-  Heist_Stat1: Stats
-  Heist_AddStatValue1: i32
-  Heist_AddStatValue2: i32
+  Stat7Value: i32 @interval
+  Stat7: Stats
+  Stat8: Stats
+  Stat8Value: i32 @interval
   InfluenceType: InfluenceTypes
   ImplicitTags: [Tags]
   _: bool


### PR DESCRIPTION
Looks like these can be used by any mods, not just heist