### PR TITLE
PoE1: add KeywordPopups tables (3.29)

### DIFF
--- a/dat-schema/3_29_Curse_of_the_Allflame.gql
+++ b/dat-schema/3_29_Curse_of_the_Allflame.gql
@@ -117,33 +117,3 @@ type DeepwaterUpgrades {
   Stats: [Stats]
   StatsValues: [i32]
 }
-
-# Ported from PoE2 in 3.29
-type KeywordPopupItemReference {
-  Id: string
-  BaseItemType: BaseItemTypes
-  UniqueName: Words
-  ItemVisualIdentity: ItemVisualIdentity
-  FlavourText: FlavourText
-  Rarity: Rarity
-  ItemLevel: i32
-  _: bool
-}
-
-# Ported from PoE2 in 3.29
-type KeywordPopupModReference {
-  Id: string
-  Mod: Mods
-  StatDescription: string @file(ext: ".csd")
-}
-
-# Ported from PoE2 in 3.29
-type KeywordPopups {
-  Id: string @unique
-  Term: string
-  Definition: string
-  _: string
-  _: string
-  ItemReference: KeywordPopupItemReference
-  ModReference: KeywordPopupModReference
-}

--- a/dat-schema/3_29_Curse_of_the_Allflame.gql
+++ b/dat-schema/3_29_Curse_of_the_Allflame.gql
@@ -117,3 +117,33 @@ type DeepwaterUpgrades {
   Stats: [Stats]
   StatsValues: [i32]
 }
+
+# Ported from PoE2 in 3.29
+type KeywordPopupItemReference {
+  Id: string
+  BaseItemType: BaseItemTypes
+  UniqueName: Words
+  ItemVisualIdentity: ItemVisualIdentity
+  FlavourText: FlavourText
+  Rarity: Rarity
+  ItemLevel: i32
+  _: bool
+}
+
+# Ported from PoE2 in 3.29
+type KeywordPopupModReference {
+  Id: string
+  Mod: Mods
+  StatDescription: string @file(ext: ".csd")
+}
+
+# Ported from PoE2 in 3.29
+type KeywordPopups {
+  Id: string @unique
+  Term: string
+  Definition: string
+  _: string
+  _: string
+  ItemReference: KeywordPopupItemReference
+  ModReference: KeywordPopupModReference
+}

--- a/dat-schema/_Core.gql
+++ b/dat-schema/_Core.gql
@@ -2752,6 +2752,36 @@ type JobRaidBrackets {
   _: i32
 }
 
+# Added 3.29
+type KeywordPopupItemReference {
+  Id: string
+  BaseItemType: BaseItemTypes
+  UniqueName: Words
+  ItemVisualIdentity: ItemVisualIdentity
+  FlavourText: FlavourText
+  Rarity: Rarity
+  ItemLevel: i32
+  _: bool
+}
+
+# Added 3.29
+type KeywordPopupModReference {
+  Id: string
+  Mod: Mods
+  StatDescription: string @file(ext: ".csd")
+}
+
+# Added 3.29
+type KeywordPopups {
+  Id: string @unique
+  Term: string
+  Definition: string
+  _: string
+  _: string
+  ItemReference: KeywordPopupItemReference
+  ModReference: KeywordPopupModReference
+}
+
 type KillstreakThresholds {
   Kills: i32
   "Monster that plays the effect, i.e. the 'nova' etc."


### PR DESCRIPTION
3.29 (Curse of the Allflame) added the keyword popup tables to the PoE1 client: `Data/KeywordPopups.datc64`, `Data/KeywordPopupItemReference.datc64`, `Data/KeywordPopupModReference.datc64`. These are the same tables PoE2 has had in `poe2/_Core.gql` — GGG ported them over unchanged, so the definitions here are verbatim copies of the PoE2 ones.

Byte-layout verified against the 3.29.0 client:

| Table | Rows | Row size | Layout check |
|---|---|---|---|
| `KeywordPopups` | 32 | 72 | 5 strings + 2 foreignrows = 5×8 + 2×16 ✓ |
| `KeywordPopupItemReference` | 2 | 93 | string + 5 foreignrows + i32 + bool = 8 + 80 + 4 + 1 ✓ |
| `KeywordPopupModReference` | 0 | — | empty at launch, spec copied from PoE2 |

Content spot-checks:
- `KeywordPopups`: `Term`/`Definition` decode cleanly for all 32 rows (Valour, Enshrouded Item, Pact Boons/Afflictions, the reworked Abyss terms, the new keystones, etc.). Row 0 is a literal GGG `Test` row.
- `KeywordPopupItemReference`: its 2 rows (`ScryingOrb`, `DeadMansSulphur`) are exactly the 2 `KeywordPopups` rows with a non-null `ItemReference` and empty `Term`/`Definition`; their `BaseItemType` foreignrows resolve to matching rows in `BaseItemTypes`.
- All other foreignrow columns are null in the current data, so their targets are taken on trust from the PoE2 schema.

`npm run generate` passes; the tables emit into `schema-poe1.min.json` with `validFor: 1`.
