### PR TITLE
Add missing StashId enum entries for Breach, Abyss and Relic stashes

### DIFF
--- a/dat-schema/poe2/_Core.gql
+++ b/dat-schema/poe2/_Core.gql
@@ -6626,6 +6626,9 @@ enum StashId @indexing(first: 0) {
   SOCKETABLE
   EXPEDITION
   RITUAL
+  BREACH
+  ABYSS
+  RELIC
 }
 
 # Added 0.1


### PR DESCRIPTION
Support for new stash tab types:

* Added `BREACH`, `ABYSS`, and `RELIC` values to the `StashId` enum in `dat-schema/poe2/_Core.gql`